### PR TITLE
Fix XSS in augendiagnose website

### DIFF
--- a/augendiagnose/web/de/header.php
+++ b/augendiagnose/web/de/header.php
@@ -1,9 +1,9 @@
 <p>
-	<a href="<?=$urlprefix?>/en/<?=$pagepathname?>">English</a>
-	Deutsch
-	<a href="<?=$urlprefix?>/es/<?=$pagepathname?>">Español</a>
-	<a href="<?=$urlprefix?>/pt/<?=$pagepathname?>">Português</a>
-	<a href="<?=$urlprefix?>/fr/<?=$pagepathname?>">Français</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">English</a>
+        Deutsch
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Español</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Português</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Français</a>
 </p>
 
 <?php 
@@ -11,7 +11,7 @@ if (!$nopageselected) {
 ?>
 <div id="navigationbutton" class="mobile">
 	<a href="javascript:void(0);" onclick="toggleNavigation()">
-		<img alt="Home" src="<?=$basepath?>/drawable/ic_menu.png">
+                <img alt="Home" src="<?=htmlspecialchars($basepath, ENT_QUOTES, 'UTF-8')?>/drawable/ic_menu.png">
 	</a>
 </div>
 <?php 

--- a/augendiagnose/web/de/navigation.php
+++ b/augendiagnose/web/de/navigation.php
@@ -1,35 +1,35 @@
 <h2 class="mobile"><span class="hideondropdown"><?=$appname?> - </span>Inhalt</h2>
 
 <p>
-	<a href="<?=$urlprefix?>/de/overview/">Übersicht</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/overview/">Übersicht</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/de/settings/">Einstellungen</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/settings/">Einstellungen</a>
 </p>
 
 <?PHP
 if (isAugendiagnose ()) {
 	?>
 <p>
-	<a href="<?=$urlprefix?>/de/organize_photos/">Organisation der Fotos</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/organize_photos/">Organisation der Fotos</a>
 </p>
 <?PHP
 }
 ?>
 
 <p>
-	<a href="<?=$urlprefix?>/de/display_photos/">Fotos ansehen</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/display_photos/">Fotos ansehen</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/de/windowsapp/">Die Windows-Anwendung</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/windowsapp/">Die Windows-Anwendung</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/de/downloads/">Downloads</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/downloads/">Downloads</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/de/impressum/">Impressum</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/impressum/">Impressum</a>
 </p>

--- a/augendiagnose/web/de/windowsapp.php
+++ b/augendiagnose/web/de/windowsapp.php
@@ -106,5 +106,5 @@
 </ul>
 
 <h3>
-	<a href="<?=$urlprefix?>/de/downloads/">Zur Download-Seite</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/downloads/">Zur Download-Seite</a>
 </h3>

--- a/augendiagnose/web/en/header.php
+++ b/augendiagnose/web/en/header.php
@@ -1,9 +1,9 @@
 <p>
 	English
-	<a href="<?=$urlprefix?>/de/<?=$pagepathname?>">Deutsch</a>
-	<a href="<?=$urlprefix?>/es/<?=$pagepathname?>">Español</a>
-	<a href="<?=$urlprefix?>/pt/<?=$pagepathname?>">Português</a>
-	<a href="<?=$urlprefix?>/fr/<?=$pagepathname?>">Français</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Deutsch</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Español</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Português</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Français</a>
 </p>
 
 <?php 
@@ -11,7 +11,7 @@ if (!$nopageselected) {
 ?>
 <div id="navigationbutton" class="mobile">
 	<a href="javascript:void(0);" onclick="toggleNavigation()">
-		<img alt="Home" src="<?=$basepath?>/drawable/ic_menu.png">
+                <img alt="Home" src="<?=htmlspecialchars($basepath, ENT_QUOTES, 'UTF-8')?>/drawable/ic_menu.png">
 	</a>
 </div>
 <?php 

--- a/augendiagnose/web/en/navigation.php
+++ b/augendiagnose/web/en/navigation.php
@@ -1,35 +1,35 @@
 <h2 class="mobile"><span class="hideondropdown"><?=$appname?> - </span>Content</h2>
 
 <p>
-	<a href="<?=$urlprefix?>/en/overview/">Overview</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/overview/">Overview</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/en/settings/">Settings</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/settings/">Settings</a>
 </p>
 
 <?PHP
 if (isAugendiagnose ()) {
 	?>
 <p>
-	<a href="<?=$urlprefix?>/en/organize_photos/">Organize the photos</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/organize_photos/">Organize the photos</a>
 </p>
 <?PHP
 }
 ?>
 
 <p>
-	<a href="<?=$urlprefix?>/en/display_photos/">View photos</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/display_photos/">View photos</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/en/windowsapp/">The Windows application</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/windowsapp/">The Windows application</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/en/downloads/">Downloads</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/downloads/">Downloads</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/en/impressum/">Legal Notice</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/impressum/">Legal Notice</a>
 </p>

--- a/augendiagnose/web/en/windowsapp.php
+++ b/augendiagnose/web/en/windowsapp.php
@@ -98,5 +98,5 @@
 </ul>
 
 <h3>
-	<a href="<?=$urlprefix?>/en/downloads/">Go to download page</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/downloads/">Go to download page</a>
 </h3>

--- a/augendiagnose/web/es/header.php
+++ b/augendiagnose/web/es/header.php
@@ -1,9 +1,9 @@
 <p>
-	<a href="<?=$urlprefix?>/en/<?=$pagepathname?>">English</a>
-	<a href="<?=$urlprefix?>/de/<?=$pagepathname?>">Deutsch</a>
-	Español
-	<a href="<?=$urlprefix?>/pt/<?=$pagepathname?>">Português</a>
-	<a href="<?=$urlprefix?>/fr/<?=$pagepathname?>">Français</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">English</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Deutsch</a>
+        Español
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Português</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Français</a>
 </p>
 
 <?php 
@@ -11,7 +11,7 @@ if (!$nopageselected) {
 ?>
 <div id="navigationbutton" class="mobile">
 	<a href="javascript:void(0);" onclick="toggleNavigation()">
-		<img alt="Home" src="<?=$basepath?>/drawable/ic_menu.png">
+                <img alt="Home" src="<?=htmlspecialchars($basepath, ENT_QUOTES, 'UTF-8')?>/drawable/ic_menu.png">
 	</a>
 </div>
 <?php 

--- a/augendiagnose/web/es/navigation.php
+++ b/augendiagnose/web/es/navigation.php
@@ -1,35 +1,35 @@
 <h2 class="mobile"><span class="hideondropdown"><?=$appname?> - </span>Contenido</h2>
 
 <p>
-	<a href="<?=$urlprefix?>/es/overview/">Información general</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/overview/">Información general</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/es/settings/">Ajustes</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/settings/">Ajustes</a>
 </p>
 
 <?PHP
 if (isAugendiagnose ()) {
 	?>
 <p>
-	<a href="<?=$urlprefix?>/es/organize_photos/">Organizar nuevas fotos</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/organize_photos/">Organizar nuevas fotos</a>
 </p>
 <?PHP
 }
 ?>
 
 <p>
-	<a href="<?=$urlprefix?>/es/display_photos/">Ver fotos</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/display_photos/">Ver fotos</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/es/windowsapp/">La aplicación para Windows</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/windowsapp/">La aplicación para Windows</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/es/downloads/">Descargas</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/downloads/">Descargas</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/es/impressum/">Aviso legal</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/impressum/">Aviso legal</a>
 </p>

--- a/augendiagnose/web/es/windowsapp.php
+++ b/augendiagnose/web/es/windowsapp.php
@@ -105,5 +105,5 @@
 </ul>
 
 <h3>
-	<a href="<?=$urlprefix?>/es/downloads/">Ir a la página de descarga</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/downloads/">Ir a la página de descarga</a>
 </h3>

--- a/augendiagnose/web/fr/header.php
+++ b/augendiagnose/web/fr/header.php
@@ -1,9 +1,9 @@
 <p>
-	<a href="<?=$urlprefix?>/en/<?=$pagepathname?>">English</a>
-	<a href="<?=$urlprefix?>/de/<?=$pagepathname?>">Deutsch</a>
-	<a href="<?=$urlprefix?>/es/<?=$pagepathname?>">Español</a>
-	<a href="<?=$urlprefix?>/pt/<?=$pagepathname?>">Português</a>
-	Français
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">English</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Deutsch</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Español</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Português</a>
+        Français
 </p>
 
 <?php 
@@ -11,7 +11,7 @@ if (!$nopageselected) {
 ?>
 <div id="navigationbutton" class="mobile">
 	<a href="javascript:void(0);" onclick="toggleNavigation()">
-		<img alt="Home" src="<?=$basepath?>/drawable/ic_menu.png">
+                <img alt="Home" src="<?=htmlspecialchars($basepath, ENT_QUOTES, 'UTF-8')?>/drawable/ic_menu.png">
 	</a>
 </div>
 <?php 

--- a/augendiagnose/web/fr/navigation.php
+++ b/augendiagnose/web/fr/navigation.php
@@ -1,35 +1,35 @@
 <h2 class="mobile"><span class="hideondropdown"><?=$appname?> - </span>Contenu</h2>
 
 <p>
-    <a href="<?=$urlprefix?>/fr/overview/">Vue d'ensemble</a>
+    <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/overview/">Vue d'ensemble</a>
 </p>
 
 <p>
-    <a href="<?=$urlprefix?>/fr/settings/">Paramètres</a>
+    <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/settings/">Paramètres</a>
 </p>
 
 <?PHP
 if (isAugendiagnose ()) {
     ?>
 <p>
-    <a href="<?=$urlprefix?>/fr/organize_photos/">Organiser les photos</a>
+    <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/organize_photos/">Organiser les photos</a>
 </p>
 <?PHP
 }
 ?>
 
 <p>
-    <a href="<?=$urlprefix?>/fr/display_photos/">Afficher les photos</a>
+    <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/display_photos/">Afficher les photos</a>
 </p>
 
 <p>
-    <a href="<?=$urlprefix?>/fr/windowsapp/">L'application Windows</a>
+    <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/windowsapp/">L'application Windows</a>
 </p>
 
 <p>
-    <a href="<?=$urlprefix?>/fr/downloads/">Téléchargements</a>
+    <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/downloads/">Téléchargements</a>
 </p>
 
 <p>
-    <a href="<?=$urlprefix?>/fr/impressum/">Mentions légales</a>
+    <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/impressum/">Mentions légales</a>
 </p>

--- a/augendiagnose/web/fr/windowsapp.php
+++ b/augendiagnose/web/fr/windowsapp.php
@@ -107,5 +107,5 @@
 </ul>
 
 <h3>
-	<a href="<?=$urlprefix?>/fr/downloads/">Aller à la page de téléchargement</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/downloads/">Aller à la page de téléchargement</a>
 </h3>

--- a/augendiagnose/web/index.php
+++ b/augendiagnose/web/index.php
@@ -1,40 +1,47 @@
 <?PHP
 $basepath = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
 
-// Determine language
-if (! empty ( $_GET ["lang"] )) {
-	$language = $_GET ["lang"];
-}
-else {
-	if (strstr ( @$_SERVER ['HTTP_ACCEPT_LANGUAGE'], "de" )) {
-		$language = "de";
-	}
-	else if (strstr ( @$_SERVER ['HTTP_ACCEPT_LANGUAGE'], "es" )) {
-		$language = "es";
-	}
-	else if (strstr ( @$_SERVER ['HTTP_ACCEPT_LANGUAGE'], "pt" )) {
-		$language = "pt";
-	}
-	else if (strstr ( @$_SERVER ['HTTP_ACCEPT_LANGUAGE'], "fr" )) {
-		$language = "fr";
-	}
-	else {
-		$language = "en";
-	}
+// Determine language with whitelist to avoid script injection
+$allowedLanguages = array("de", "en", "es", "pt", "fr");
+if (!empty($_GET["lang"]) && in_array($_GET["lang"], $allowedLanguages, true)) {
+        $language = $_GET["lang"];
+} else {
+        if (strstr(@$_SERVER['HTTP_ACCEPT_LANGUAGE'], "de")) {
+                $language = "de";
+        } elseif (strstr(@$_SERVER['HTTP_ACCEPT_LANGUAGE'], "es")) {
+                $language = "es";
+        } elseif (strstr(@$_SERVER['HTTP_ACCEPT_LANGUAGE'], "pt")) {
+                $language = "pt";
+        } elseif (strstr(@$_SERVER['HTTP_ACCEPT_LANGUAGE'], "fr")) {
+                $language = "fr";
+        } else {
+                $language = "en";
+        }
 }
 
+$allowedPages = array(
+        "overview",
+        "display_photos",
+        "organize_photos",
+        "settings",
+        "windowsapp",
+        "downloads",
+        "impressum"
+);
+
 if (isset($page)) {
-	$nopageselected = false;
-}
-else {
-	if (empty ( $_GET ["page"] )) {
-		$page = "overview";
-		$nopageselected = true;
-	}
-	else {
-		$page = $_GET ["page"];
-		$nopageselected = false;
-	}
+        $nopageselected = false;
+} else {
+        if (empty($_GET["page"])) {
+                $page = "overview";
+                $nopageselected = true;
+        } else {
+                $page = $_GET["page"];
+                if (!in_array($page, $allowedPages, true)) {
+                        $page = "overview";
+                }
+                $nopageselected = false;
+        }
 }
 
 $pagefull = $page . ".php";
@@ -127,17 +134,17 @@ else {
 	?>
 
 <!DOCTYPE html>
-<html lang="<?=$language?>">
+<html lang="<?=htmlspecialchars($language, ENT_QUOTES, 'UTF-8')?>">
 <head>
-<title><?=$title?></title>
+<title><?=htmlspecialchars($title, ENT_QUOTES, 'UTF-8')?></title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta http-equiv="Content-Language" content="<?=$language?>">
-<meta name="description" content="<?=$description?>">
-<meta name="keywords" content="<?=$keywords?>">
+<meta http-equiv="Content-Language" content="<?=htmlspecialchars($language, ENT_QUOTES, 'UTF-8')?>">
+<meta name="description" content="<?=htmlspecialchars($description, ENT_QUOTES, 'UTF-8')?>">
+<meta name="keywords" content="<?=htmlspecialchars($keywords, ENT_QUOTES, 'UTF-8')?>">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link href="<?=$basepath?>/stylesheets/styles.css" rel="Stylesheet" type="text/css">
-<link rel="shortcut icon" href="<?=$basepath?>/drawable/icon_<?=$app?>.ico">
-<script type="text/javascript" src="<?=$basepath?>/javascript/jquery-3.5.1.min.js"></script>
+<link href="<?=htmlspecialchars($basepath, ENT_QUOTES, 'UTF-8')?>/stylesheets/styles.css" rel="Stylesheet" type="text/css">
+<link rel="shortcut icon" href="<?=htmlspecialchars($basepath, ENT_QUOTES, 'UTF-8')?>/drawable/icon_<?=htmlspecialchars($app, ENT_QUOTES, 'UTF-8')?>.ico">
+<script type="text/javascript" src="<?=htmlspecialchars($basepath, ENT_QUOTES, 'UTF-8')?>/javascript/jquery-3.5.1.min.js"></script>
 <script>
 function toggleNavigation() {
 	$("#navigationframe").toggleClass( "mobilenavigation" );

--- a/augendiagnose/web/pt/header.php
+++ b/augendiagnose/web/pt/header.php
@@ -1,9 +1,9 @@
 <p>
-	<a href="<?=$urlprefix?>/en/<?=$pagepathname?>">English</a>
-	<a href="<?=$urlprefix?>/de/<?=$pagepathname?>">Deutsch</a>
-	<a href="<?=$urlprefix?>/es/<?=$pagepathname?>">Español</a>
-	Português
-	<a href="<?=$urlprefix?>/fr/<?=$pagepathname?>">Français</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/en/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">English</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/de/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Deutsch</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/es/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Español</a>
+        Português
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/fr/<?=htmlspecialchars($pagepathname, ENT_QUOTES, 'UTF-8')?>">Français</a>
 </p>
 
 <?php 
@@ -11,7 +11,7 @@ if (!$nopageselected) {
 ?>
 <div id="navigationbutton" class="mobile">
 	<a href="javascript:void(0);" onclick="toggleNavigation()">
-		<img alt="Home" src="<?=$basepath?>/drawable/ic_menu.png">
+                <img alt="Home" src="<?=htmlspecialchars($basepath, ENT_QUOTES, 'UTF-8')?>/drawable/ic_menu.png">
 	</a>
 </div>
 <?php 

--- a/augendiagnose/web/pt/navigation.php
+++ b/augendiagnose/web/pt/navigation.php
@@ -1,35 +1,35 @@
 <h2 class="mobile"><span class="hideondropdown"><?=$appname?> - </span>Conteúdo</h2>
 
 <p>
-	<a href="<?=$urlprefix?>/pt/overview/">Informações gerais</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/overview/">Informações gerais</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/pt/settings/">Ajustes</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/settings/">Ajustes</a>
 </p>
 
 <?PHP
 if (isAugendiagnose ()) {
 	?>
 <p>
-	<a href="<?=$urlprefix?>/pt/organize_photos/">Organize novas fotos</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/organize_photos/">Organize novas fotos</a>
 </p>
 <?PHP
 }
 ?>
 
 <p>
-	<a href="<?=$urlprefix?>/pt/display_photos/">Visualizar fotos</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/display_photos/">Visualizar fotos</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/pt/windowsapp/">O aplicativo para o Windows</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/windowsapp/">O aplicativo para o Windows</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/pt/downloads/">Downloads</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/downloads/">Downloads</a>
 </p>
 
 <p>
-	<a href="<?=$urlprefix?>/pt/impressum/">Aviso Legal</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/impressum/">Aviso Legal</a>
 </p>

--- a/augendiagnose/web/pt/windowsapp.php
+++ b/augendiagnose/web/pt/windowsapp.php
@@ -102,5 +102,5 @@
 </ul>
 
 <h3>
-	<a href="<?=$urlprefix?>/pt/downloads/">Vá para a página de download</a>
+        <a href="<?=htmlspecialchars($urlprefix, ENT_QUOTES, 'UTF-8')?>/pt/downloads/">Vá para a página de download</a>
 </h3>


### PR DESCRIPTION
## Summary
- sanitize `lang` and `page` parameters
- escape dynamic variables in HTML templates

## Testing
- `php -l augendiagnose/web/index.php`
- `php -l augendiagnose/web/en/header.php`
- `php -l augendiagnose/web/de/header.php`
- `php -l augendiagnose/web/es/header.php`
- `php -l augendiagnose/web/fr/header.php`
- `php -l augendiagnose/web/pt/header.php`
- `php -l augendiagnose/web/en/navigation.php`
- `php -l augendiagnose/web/de/navigation.php`
- `php -l augendiagnose/web/es/navigation.php`
- `php -l augendiagnose/web/fr/navigation.php`
- `php -l augendiagnose/web/pt/navigation.php`
- `php -l augendiagnose/web/en/windowsapp.php`
- `php -l augendiagnose/web/de/windowsapp.php`
- `php -l augendiagnose/web/es/windowsapp.php`
- `php -l augendiagnose/web/fr/windowsapp.php`
- `php -l augendiagnose/web/pt/windowsapp.php`


------
https://chatgpt.com/codex/tasks/task_e_687e6df835f88322b94b9479e2dab1dc