### PR TITLE
Add admin view with basic auth and edit action placeholder

### DIFF
--- a/heilsame-lieder/web/admin/.htaccess
+++ b/heilsame-lieder/web/admin/.htaccess
@@ -1,0 +1,10 @@
+# Restrict access to the admin area
+AuthType Basic
+AuthName "Heilsame Lieder Admin"
+# Update the following path to match the server's absolute path to this .htpasswd file if necessary.
+AuthUserFile /var/www/html/admin/.htpasswd
+Require valid-user
+
+<Files ".ht*">
+        Require all denied
+</Files>

--- a/heilsame-lieder/web/admin/.htpasswd
+++ b/heilsame-lieder/web/admin/.htpasswd
@@ -1,0 +1,1 @@
+admin:$apr1$xbDL5i18$QclhmKT7bObWLJ7D6BjBo/

--- a/heilsame-lieder/web/admin/index.html
+++ b/heilsame-lieder/web/admin/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head prefix="og: http://ogp.me/ns#">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex, nofollow">
+<meta name="keywords" content="Heilsame Lieder, Kreiskultur, Musik, Singen, Gitarre, Mantras, Mantren, Chants, Chanten, Chanting, Music, Singing, Guitar, Singkreis">
+<meta name="description" content="Administrativer Zugriff auf das Archiv Heilsamer Lieder."/>
+<title>Heilsame Lieder – Admin</title>
+<link rel="stylesheet" href="/css/songbook.css">
+</head>
+<body class="admin-view">
+
+        <div class="container">
+                <div class="page-heading">
+                        <img src="/img/logo4a.png" alt="Icon" class="heading-icon">
+                        <h2 id="heilsame-lieder">Heilsame Lieder</h2>
+                        <img src="/img/logo4a.png" alt="Icon" class="heading-icon">
+                </div>
+
+                <!-- Search Box with Local PNG Icon -->
+                <div class="search-container">
+                        <img src="/img/search2.png" alt="Search"> <input type="text" id="searchBox" placeholder="Search..."
+                                oninput="toggleClearButton()" onkeyup="searchSongs()">
+                        <button id="clearButton" onclick="clearSearch()">✕</button>
+                </div>
+
+                <!-- Table for Results -->
+                <table>
+                        <thead>
+                                <tr>
+                                        <th id="id">ID</th>
+                                        <th id="title">Title</th>
+                                        <th id="author" class="author-col">Author(s)</th>
+                                        <th id="actions">Actions</th>
+                                </tr>
+                        </thead>
+                        <tbody id="results"></tbody>
+                </table>
+        </div>
+
+        <!-- Popup Container -->
+        <div id="popup" class="popup" style="display: none;">
+                <div class="popup-content">
+                        <span class="popup-close" onclick="closePopup('popup')">&times;</span>
+                        <div id="popup-body"></div>
+                </div>
+        </div>
+        <div id="popup2" class="popup" style="display: none;">
+                <div class="popup-content">
+                        <span class="popup-close" onclick="closePopup('popup2')">&times;</span>
+                        <div id="popup2-body"></div>
+                </div>
+        </div>
+
+        <a href="https://play.google.com/store/apps/details?id=de.jeisfeld.songarchive" class="androidapp" id="androidapp-link" target="_blank">Android App</a>
+
+        <a href="/impressum.html" class="impressum" id="impressum-link">Imprint</a>
+
+        <!-- Modal Structure -->
+        <div id="modal-main" class="modal">
+                <div class="modal-content">
+                        <!-- A close button and a placeholder; content will be loaded here -->
+                        <span class="modal-close" id="close-modal">&times;</span>
+                        <div id="modal-content">
+                                <!-- Impressum content from impressum.html will appear here -->
+                        </div>
+                </div>
+        </div>
+
+        <script src="/js/songbook.js"></script>
+</body>
+</html>

--- a/heilsame-lieder/web/img/edit.svg
+++ b/heilsame-lieder/web/img/edit.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#F9F8E1" stroke="#4D4313" stroke-width="1"/>
+  <path d="M6 16.5V18h1.5l7.9-7.9-1.5-1.5L6 16.5z" fill="#F7F5C4" stroke="#4D4313" stroke-width="1" stroke-linejoin="round"/>
+  <path d="M15.46 7.04l1.5 1.5 1.27-1.27a1.06 1.06 0 0 0 0-1.5l-.5-.5a1.06 1.06 0 0 0-1.5 0l-1.27 1.27z" fill="#F9F8E1" stroke="#4D4313" stroke-width="1" stroke-linejoin="round"/>
+  <line x1="7.2" y1="17" x2="16.5" y2="7.7" stroke="#4D4313" stroke-width="1" stroke-linecap="round"/>
+</svg>

--- a/heilsame-lieder/web/js/songbook.js
+++ b/heilsame-lieder/web/js/songbook.js
@@ -1,5 +1,6 @@
 let searchAbortController = new AbortController(); // Create a controller
 let searchTimeout = null;
+const isAdminView = document.body.classList.contains("admin-view");
 
 // functions related to song search
 function searchSongs(inputquery = null) {
@@ -45,15 +46,20 @@ async function performSearch(query) {
 
 function displayResult(songs) {
 	let tableHTML = "";
-	songs.forEach(song => {
-		tableHTML += `
-			<tr>
-				<td><a href="?q=${song.id}" class="unformatted-link" target="_blank">${song.id}</a></td>
-				<td>${song.title}</td>
-				<td class="author-col">${formatAuthors(song.author || "")}</td>
-				<td class="actions">
-					<div class="actions-container">
-						<img src="/img/text2.png" alt="View Lyrics" class="icon-btn" onclick="showLyrics('${song.id}', '${song.title}')">
+        songs.forEach(song => {
+                const editButtonHTML = isAdminView
+                        ? `<img src="/img/edit.svg" alt="Edit Song" class="icon-btn edit-btn" data-song-id="${song.id}" title="Edit (coming soon)">`
+                        : "";
+
+                tableHTML += `
+                        <tr>
+                                <td><a href="?q=${song.id}" class="unformatted-link" target="_blank">${song.id}</a></td>
+                                <td>${song.title}</td>
+                                <td class="author-col">${formatAuthors(song.author || "")}</td>
+                                <td class="actions">
+                                        <div class="actions-container">
+                                                ${editButtonHTML}
+                                                <img src="/img/text2.png" alt="View Lyrics" class="icon-btn" onclick="showLyrics('${song.id}', '${song.title}')">
 						${song.tabfilename ? `<img src="/img/chords2.png" alt="View Image" class="icon-btn" onclick="showImage('${song.tabfilename}')">` : ""}
 						${song.mp3filename ? `
 							<img src="/img/play2.png" alt="Play Audio" class="icon-btn"


### PR DESCRIPTION
## Summary
- add a password-protected admin area that mirrors the public song list but flags the view as admin
- wire the shared songbook script to detect the admin view and show a placeholder Edit button ahead of the other actions
- introduce an edit icon asset and Apache basic-auth configuration, including credentials for the new admin area

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68cbee232f1483229d9eaca499f3649a