### PR TITLE
Add tab filename suggestions from song images folder

### DIFF
--- a/heilsame-lieder/web/admin/editsong.php
+++ b/heilsame-lieder/web/admin/editsong.php
@@ -112,14 +112,18 @@ function buildFilenameSuggestions($directory, array $priorityPrefixes = []) {
 }
 
 function renderFilenameNote(array $matching, array $options, $prefix, $directoryExists, $folderPath) {
-    if (! empty($matching)) {
-        echo "<div class=\"form-note\">Matching files: " . implode(', ', array_map('escapeHtml', $matching)) . "</div>";
-    } elseif (! empty($options) && $prefix !== '') {
-        echo "<div class=\"form-note\">No files found in " . escapeHtml($folderPath) . " starting with " . escapeHtml($prefix) . ".</div>";
-    } elseif (empty($options) && $directoryExists) {
-        echo "<div class=\"form-note\">No files found in " . escapeHtml($folderPath) . ".</div>";
-    } elseif (! $directoryExists) {
+    if (! $directoryExists) {
         echo "<div class=\"form-note\">Folder " . escapeHtml($folderPath) . " is not available.</div>";
+        return;
+    }
+
+    if (empty($options)) {
+        echo "<div class=\"form-note\">No files found in " . escapeHtml($folderPath) . ".</div>";
+        return;
+    }
+
+    if ($prefix !== '' && empty($matching)) {
+        echo "<div class=\"form-note\">No files found in " . escapeHtml($folderPath) . " starting with " . escapeHtml($prefix) . ".</div>";
     }
 }
 


### PR DESCRIPTION
## Summary
- collect image filenames from img/songs/ to support tab selection
- surface matches for the song ID prefix and provide a datalist for quick entry
- add helper styling for the tab filename field note

## Testing
- php -l heilsame-lieder/web/admin/editsong.php

------
https://chatgpt.com/codex/tasks/task_e_68cd1435a1c48322955acf40c8a18230