### PR TITLE
Add admin modal for inserting songs

### DIFF
--- a/heilsame-lieder/web/admin/addsong.php
+++ b/heilsame-lieder/web/admin/addsong.php
@@ -1,0 +1,223 @@
+<?php
+header('Content-Type: text/html; charset=UTF-8');
+
+require_once __DIR__ . '/../db_config.php';
+
+function escapeHtml($value)
+{
+    return htmlspecialchars((string) ($value ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+$formValues = [
+    'id' => '',
+    'title' => '',
+    'lyrics' => '',
+];
+
+$errorMessage = '';
+$insertSuccess = false;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $formValues['id'] = isset($_POST['id']) ? trim($_POST['id']) : '';
+    $formValues['title'] = isset($_POST['title']) ? trim($_POST['title']) : '';
+    $lyricsInput = isset($_POST['lyrics']) ? $_POST['lyrics'] : '';
+    $formValues['lyrics'] = $lyricsInput;
+
+    if ($formValues['id'] === '' || $formValues['title'] === '' || trim($lyricsInput) === '') {
+        $errorMessage = 'Please fill in all required fields.';
+    } else {
+        $insertSql = 'INSERT INTO songs (id, title, lyrics) VALUES (?, ?, ?)';
+        $insertStmt = $conn->prepare($insertSql);
+
+        if (! $insertStmt) {
+            error_log('Failed to prepare insert statement: ' . $conn->error);
+            $errorMessage = 'Unable to prepare the song for saving.';
+        } else {
+            $insertStmt->bind_param('sss', $formValues['id'], $formValues['title'], $lyricsInput);
+
+            if ($insertStmt->execute()) {
+                $insertSuccess = true;
+            } else {
+                if ($insertStmt->errno === 1062) {
+                    $errorMessage = 'A song with this ID already exists.';
+                } else {
+                    error_log('Failed to execute insert statement: ' . $insertStmt->error);
+                    $errorMessage = 'Failed to save the song.';
+                }
+            }
+
+            $insertStmt->close();
+        }
+    }
+}
+
+if (isset($conn) && $conn instanceof mysqli) {
+    $conn->close();
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Add New Song</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f7f7f2;
+            color: #333;
+        }
+        .add-song-container {
+            max-width: 720px;
+            margin: 0 auto;
+        }
+        h1 {
+            font-size: 1.75rem;
+            margin-bottom: 16px;
+        }
+        .form-group {
+            margin-bottom: 15px;
+        }
+        .form-group label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 6px;
+        }
+        .required-indicator {
+            color: #d9534f;
+            margin-left: 4px;
+        }
+        .form-group input[type="text"],
+        .form-group textarea {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #c5c5c5;
+            border-radius: 4px;
+            box-sizing: border-box;
+            font-size: 1rem;
+            font-family: inherit;
+        }
+        .form-group textarea {
+            min-height: 200px;
+            resize: vertical;
+            line-height: 1.4;
+        }
+        .form-note {
+            font-size: 0.9rem;
+            color: #555;
+            margin-top: 4px;
+        }
+        .button-row {
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+            margin-top: 20px;
+        }
+        .button-row button {
+            padding: 10px 18px;
+            font-size: 1rem;
+            border-radius: 4px;
+            border: 1px solid transparent;
+            cursor: pointer;
+        }
+        .button-row .save-btn {
+            background-color: #4CAF50;
+            border-color: #4CAF50;
+            color: #fff;
+        }
+        .button-row .save-btn:hover {
+            background-color: #45a049;
+        }
+        .button-row .cancel-btn {
+            background-color: #f0f0f0;
+            border-color: #ccc;
+            color: #333;
+        }
+        .button-row .cancel-btn:hover {
+            background-color: #e0e0e0;
+        }
+        .alert {
+            padding: 12px 16px;
+            border-radius: 4px;
+            margin-bottom: 18px;
+            border: 1px solid transparent;
+        }
+        .alert-error {
+            background-color: #f8d7da;
+            border-color: #f5c6cb;
+            color: #721c24;
+        }
+    </style>
+</head>
+<body>
+    <div class="add-song-container">
+        <h1>Add New Song</h1>
+        <p class="form-note">Fields marked with <span class="required-indicator">*</span> are required.</p>
+
+        <?php if ($errorMessage): ?>
+            <div class="alert alert-error"><?php echo escapeHtml($errorMessage); ?></div>
+        <?php endif; ?>
+
+        <form method="post">
+            <div class="form-group">
+                <label for="song-id">Song ID <span class="required-indicator">*</span></label>
+                <input type="text" id="song-id" name="id" value="<?php echo escapeHtml($formValues['id']); ?>" required>
+            </div>
+
+            <div class="form-group">
+                <label for="song-title">Title <span class="required-indicator">*</span></label>
+                <input type="text" id="song-title" name="title" value="<?php echo escapeHtml($formValues['title']); ?>" required>
+            </div>
+
+            <div class="form-group">
+                <label for="song-lyrics">Lyrics <span class="required-indicator">*</span></label>
+                <textarea id="song-lyrics" name="lyrics" required><?php echo escapeHtml($formValues['lyrics']); ?></textarea>
+            </div>
+
+            <div class="button-row">
+                <button type="button" class="cancel-btn" id="cancel-add">Cancel</button>
+                <button type="submit" class="save-btn">Save</button>
+            </div>
+        </form>
+    </div>
+
+    <script>
+        (function() {
+            var modalOrigin = window.location.origin || (window.location.protocol + '//' + window.location.host);
+            var cancelButton = document.getElementById('cancel-add');
+            if (cancelButton) {
+                cancelButton.addEventListener('click', function() {
+                    if (window.parent && window.parent !== window) {
+                        window.parent.postMessage({ type: 'closeEditModal' }, modalOrigin);
+                    } else if (document.referrer) {
+                        window.location.href = document.referrer;
+                    } else {
+                        window.location.href = 'index.html';
+                    }
+                });
+            }
+
+            var idInput = document.getElementById('song-id');
+            if (idInput) {
+                idInput.focus();
+                idInput.select();
+            }
+        })();
+    </script>
+
+    <?php if ($insertSuccess): ?>
+        <script>
+            (function() {
+                var modalOrigin = window.location.origin || (window.location.protocol + '//' + window.location.host);
+                if (window.parent && window.parent !== window) {
+                    window.parent.postMessage({ type: 'songInserted', songId: <?php echo json_encode($formValues['id']); ?> }, modalOrigin);
+                } else {
+                    window.location.href = <?php echo json_encode('/admin/editsong.php?id=' . rawurlencode($formValues['id'])); ?>;
+                }
+            })();
+        </script>
+    <?php endif; ?>
+</body>
+</html>

--- a/heilsame-lieder/web/admin/index.html
+++ b/heilsame-lieder/web/admin/index.html
@@ -20,11 +20,12 @@
 		</div>
 
 		<!-- Search Box with Local PNG Icon -->
-		<div class="search-container">
-			<img src="/img/search2.png" alt="Search"> <input type="text" id="searchBox" placeholder="Search..."
-				oninput="toggleClearButton()" onkeyup="searchSongs()">
-			<button id="clearButton" onclick="clearSearch()">✕</button>
-		</div>
+                <div class="search-container">
+                        <img src="/img/search2.png" alt="Search"> <input type="text" id="searchBox" placeholder="Search..."
+                                oninput="toggleClearButton()" onkeyup="searchSongs()">
+                        <button id="clearButton" type="button" aria-label="Clear search" title="Clear search"
+                                onclick="clearSearch()">✕</button>
+                </div>
 
 		<!-- Table for Results -->
 		<table>

--- a/heilsame-lieder/web/admin/index.html
+++ b/heilsame-lieder/web/admin/index.html
@@ -72,5 +72,6 @@
 	</div>
 
 	<script src="/js/songbook.js"></script>
+	<script src="/js/songadmin.js"></script>
 </body>
 </html>

--- a/heilsame-lieder/web/js/songadmin.js
+++ b/heilsame-lieder/web/js/songadmin.js
@@ -1,0 +1,198 @@
+(function() {
+        if (typeof document === "undefined" || typeof window === "undefined") {
+                return;
+        }
+
+        if (!document.body || !document.body.classList.contains("admin-view")) {
+                return;
+        }
+
+        const pageOrigin = window.location.origin || `${window.location.protocol}//${window.location.host}`;
+        let adminInitialised = false;
+
+        function escapeAttribute(value) {
+                return String(value ?? "")
+                        .replace(/&/g, "&amp;")
+                        .replace(/"/g, "&quot;")
+                        .replace(/'/g, "&#39;")
+                        .replace(/</g, "&lt;")
+                        .replace(/>/g, "&gt;");
+        }
+
+        function getModalElements() {
+                return {
+                        modal: document.getElementById("modal-main"),
+                        content: document.getElementById("modal-content")
+                };
+        }
+
+        function showIframeModal(url, mode, titleText) {
+                const { modal, content } = getModalElements();
+
+                if (!modal || !content) {
+                        window.location.href = url;
+                        return;
+                }
+
+                modal.dataset.mode = mode;
+                content.innerHTML = '<div class="modal-loading">Loading...</div>';
+
+                const iframe = document.createElement("iframe");
+                iframe.src = url;
+                iframe.className = "modal-iframe";
+                iframe.setAttribute("title", titleText);
+                iframe.onload = () => {
+                        const loader = content.querySelector(".modal-loading");
+                        if (loader) {
+                                loader.remove();
+                        }
+                };
+
+                content.appendChild(iframe);
+                modal.style.display = "block";
+        }
+
+        function openEditModal(songId) {
+                if (!songId) {
+                        return;
+                }
+
+                const editUrl = `/admin/editsong.php?id=${encodeURIComponent(songId)}`;
+                showIframeModal(editUrl, "edit", `Edit song ${songId}`);
+        }
+
+        function openAddModal() {
+                const addUrl = "/admin/addsong.php";
+                showIframeModal(addUrl, "add", "Add new song");
+        }
+
+        function renderActionButtons(song) {
+                if (!song || !song.id) {
+                        return "";
+                }
+
+                const safeId = escapeAttribute(song.id);
+                return `<img src="/img/edit.svg" alt="Edit Song" class="icon-btn edit-btn" data-song-id="${safeId}" title="Edit song" role="button" tabindex="0">`;
+        }
+
+        function updateClearButton(clearButton, hasValue) {
+                if (!clearButton) {
+                        return false;
+                }
+
+                if (hasValue) {
+                        return false;
+                }
+
+                clearButton.textContent = "⊕";
+                clearButton.onclick = openAddModal;
+                clearButton.title = "Add new song";
+                clearButton.setAttribute("aria-label", "Add new song");
+
+                return true;
+        }
+
+        function handleResultsClick(event) {
+                const target = event.target.closest ? event.target.closest('.edit-btn') : event.target;
+
+                if (!target || !target.classList || !target.classList.contains('edit-btn')) {
+                        return;
+                }
+
+                event.preventDefault();
+                const songId = target.getAttribute('data-song-id');
+                openEditModal(songId);
+        }
+
+        function handleResultsKeydown(event) {
+                if (!event || (event.key !== 'Enter' && event.key !== ' ')) {
+                        return;
+                }
+
+                const target = event.target.closest ? event.target.closest('.edit-btn') : event.target;
+
+                if (!target || !target.classList || !target.classList.contains('edit-btn')) {
+                        return;
+                }
+
+                event.preventDefault();
+                const songId = target.getAttribute('data-song-id');
+                openEditModal(songId);
+        }
+
+        function handleMessage(event) {
+                const originMatches = !event.origin || event.origin === pageOrigin || (pageOrigin === 'null' && event.origin === 'null');
+
+                if (!originMatches || !event.data || typeof event.data !== 'object') {
+                        return;
+                }
+
+                const { type, songId } = event.data;
+
+                if (type === 'closeEditModal') {
+                        if (typeof hideModal === 'function') {
+                                hideModal();
+                        }
+                        return;
+                }
+
+                if (type === 'songUpdated') {
+                        if (typeof hideModal === 'function') {
+                                hideModal();
+                        }
+                        if (typeof searchSongs === 'function') {
+                                searchSongs();
+                        }
+                        return;
+                }
+
+                if (type === 'songInserted') {
+                        if (typeof hideModal === 'function') {
+                                hideModal();
+                        }
+
+                        if (songId) {
+                                openEditModal(songId);
+                        }
+
+                        if (typeof searchSongs === 'function') {
+                                searchSongs();
+                        }
+                }
+        }
+
+        function initialiseAdminFeatures() {
+                if (adminInitialised) {
+                        return;
+                }
+
+                adminInitialised = true;
+                document.removeEventListener('songbook:ready', initialiseAdminFeatures);
+                const resultsBody = document.getElementById('results');
+
+                if (resultsBody) {
+                        resultsBody.addEventListener('click', handleResultsClick);
+                        resultsBody.addEventListener('keydown', handleResultsKeydown);
+                }
+
+                window.addEventListener('message', handleMessage);
+
+                if (typeof toggleClearButton === 'function') {
+                        toggleClearButton();
+                }
+        }
+
+        window.songbookAdmin = {
+                renderActionButtons,
+                updateClearButton,
+                openEditModal,
+                openAddModal
+        };
+
+        if (window.songbookReady) {
+                initialiseAdminFeatures();
+        } else {
+                document.addEventListener('songbook:ready', initialiseAdminFeatures);
+        }
+})();
+

--- a/heilsame-lieder/web/js/songbook.js
+++ b/heilsame-lieder/web/js/songbook.js
@@ -110,18 +110,58 @@ function openEditModal(songId) {
         modal.style.display = "block";
 }
 
-function toggleClearButton() {
-	let searchBox = document.getElementById("searchBox");
-	let clearButton = document.getElementById("clearButton");
+function openAddModal() {
+        const addUrl = "/admin/addsong.php";
 
-	clearButton.classList.add("visible"); // Button always visible
-	if (searchBox.value.length > 0) {
-		clearButton.textContent = "✕";
-		clearButton.onclick = clearSearch;
-	} else {
-		clearButton.textContent = "\uD83D\uDD00"; // Shuffle icon
-		clearButton.onclick = shuffleSongs;
-	}
+        if (!modal || !impressumContent) {
+                window.location.href = addUrl;
+                return;
+        }
+
+        modal.dataset.mode = "add";
+        impressumContent.innerHTML = '<div class="modal-loading">Loading...</div>';
+
+        const iframe = document.createElement("iframe");
+        iframe.src = addUrl;
+        iframe.className = "modal-iframe";
+        iframe.setAttribute("title", "Add new song");
+        iframe.onload = () => {
+                const loader = impressumContent.querySelector(".modal-loading");
+                if (loader) {
+                        loader.remove();
+                }
+        };
+
+        impressumContent.appendChild(iframe);
+        modal.style.display = "block";
+}
+
+function toggleClearButton() {
+        const searchBox = document.getElementById("searchBox");
+        const clearButton = document.getElementById("clearButton");
+
+        if (!clearButton || !searchBox) {
+                return;
+        }
+
+        clearButton.classList.add("visible"); // Button always visible
+
+        if (searchBox.value.length > 0) {
+                clearButton.textContent = "✕";
+                clearButton.onclick = clearSearch;
+                clearButton.title = "Clear search";
+                clearButton.setAttribute("aria-label", "Clear search");
+        } else if (isAdminView) {
+                clearButton.textContent = "⊕"; // Circled plus
+                clearButton.onclick = openAddModal;
+                clearButton.title = "Add new song";
+                clearButton.setAttribute("aria-label", "Add new song");
+        } else {
+                clearButton.textContent = "\uD83D\uDD00"; // Shuffle icon
+                clearButton.onclick = shuffleSongs;
+                clearButton.title = "Shuffle songs";
+                clearButton.setAttribute("aria-label", "Shuffle songs");
+        }
 }
 
 function clearSearch() {
@@ -707,6 +747,14 @@ window.addEventListener('message', event => {
                 if (isAdminView) {
                         searchSongs();
                 }
+        } else if (type === 'songInserted') {
+                if (isAdminView) {
+                        hideModal();
+                        if (event.data.songId) {
+                                openEditModal(event.data.songId);
+                        }
+                        searchSongs();
+                }
         }
 });
 
@@ -714,9 +762,13 @@ let userAgent = navigator.userAgent || navigator.vendor || window.opera;
 let linkElement = document.getElementById("androidapp-link");
 
 if (/Android/i.test(userAgent)) {
-	linkElement.style.display = "block"; // Show link
+        linkElement.style.display = "block"; // Show link
 } else {
-	linkElement.style.display = "none"; // Hide link
+        linkElement.style.display = "none"; // Hide link
+}
+
+if (document.getElementById("clearButton")) {
+        toggleClearButton();
 }
 
 


### PR DESCRIPTION
## Summary
- replace the admin search shuffle button with an add action that launches a modal
- introduce a dedicated add-song dialog that collects the required fields and inserts the record
- refresh the admin list and transition to the existing edit view after a song is created

## Testing
- php -l admin/addsong.php

------
https://chatgpt.com/codex/tasks/task_e_68cd2ad9a62c8322af968f40703ee2a6