### PR TITLE
Add reload button to card page

### DIFF
--- a/playshopping/web/cards/index.php
+++ b/playshopping/web/cards/index.php
@@ -30,21 +30,45 @@ html, body {
 }
 
 .content {
-	width: 100%;
-	max-width: 1024px;
-	max-height: 80%;
-	text-align: center;
-	font-size: clamp(1.2rem, 4vw, 2em);
-	padding: 20px;
-	box-sizing: border-box;
-	background: white;
-	border-radius: 10px;
-	box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-	overflow-y: auto;
+        position: relative;
+        width: 100%;
+        max-width: 1024px;
+        max-height: 80%;
+        text-align: center;
+        font-size: clamp(1.2rem, 4vw, 2em);
+        padding: 20px 20px 30px;
+        box-sizing: border-box;
+        background: white;
+        border-radius: 10px;
+        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+        overflow-y: auto;
+}
+
+.reload-button {
+        position: absolute;
+        top: 15px;
+        right: 15px;
+        background: transparent;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        color: #666;
+        transition: color 0.2s ease;
+}
+
+.reload-button:hover,
+.reload-button:focus {
+        color: #000;
+        outline: none;
 }
 </style>
 </head>
 <body>
-	<div class="content"><?= nl2br(htmlspecialchars($text)) ?></div>
+        <div class="content">
+                <button type="button" class="reload-button" onclick="location.reload();" aria-label="Seite neu laden">
+                        &#x21bb;
+                </button>
+                <?= nl2br(htmlspecialchars($text)) ?>
+        </div>
 </body>
 </html>

--- a/playshopping/web/cards/index.php
+++ b/playshopping/web/cards/index.php
@@ -30,7 +30,6 @@ html, body {
 }
 
 .content {
-        position: relative;
         width: 100%;
         max-width: 1024px;
         max-height: 80%;
@@ -45,9 +44,9 @@ html, body {
 }
 
 .reload-button {
-        position: absolute;
-        top: 15px;
-        right: 15px;
+        position: fixed;
+        top: 20px;
+        right: 20px;
         background: transparent;
         border: none;
         font-size: 1.5rem;
@@ -64,10 +63,10 @@ html, body {
 </style>
 </head>
 <body>
+        <button type="button" class="reload-button" onclick="location.reload();" aria-label="Seite neu laden">
+                &#x21bb;
+        </button>
         <div class="content">
-                <button type="button" class="reload-button" onclick="location.reload();" aria-label="Seite neu laden">
-                        &#x21bb;
-                </button>
                 <?= nl2br(htmlspecialchars($text)) ?>
         </div>
 </body>


### PR DESCRIPTION
## Summary
- add a reload icon button to the card display page so users can draw a new card
- style the button to sit in the top-right corner of the card content and respond to hover/focus states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f747eb4bbc8322a18b9affd6451767