### PR TITLE
Add social media links and icons below indiewelt cover

### DIFF
--- a/jeisfeld/web/indiewelt/index.html
+++ b/jeisfeld/web/indiewelt/index.html
@@ -92,6 +92,35 @@ button:hover {
 	background: #333;
 }
 
+
+.social-links {
+	margin-top: 14px;
+	display: grid;
+	gap: 8px;
+}
+
+.social-links a {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 10px;
+	background: #161616;
+	border: 1px solid #2a2a2a;
+	border-radius: 10px;
+	color: #eee;
+	text-decoration: none;
+}
+
+.social-links a:hover {
+	background: #1d1d1d;
+}
+
+.icon {
+	width: 20px;
+	height: 20px;
+	fill: currentColor;
+}
+
 @media ( max-width : 760px) {
 	.wrap {
 		grid-template-columns: 1fr;
@@ -119,6 +148,33 @@ button:hover {
 	<div class="wrap">
 		<div>
 			<img src="cover.jpg" alt="Album cover" />
+
+			<div class="social-links">
+				<a href="https://www.youtube.com/channel/UCbn9dK6UMROi83rhPaoVjnA" target="_blank" rel="noopener noreferrer">
+					<svg class="icon" aria-hidden="true">
+						<use xlink:href="/img/icons.svg#icon-youtube"></use>
+					</svg>
+					Youtube
+				</a>
+				<a href="https://open.spotify.com/album/7GqxiaDlEQH6r72SIAENaR" target="_blank" rel="noopener noreferrer">
+					<svg class="icon" aria-hidden="true">
+						<use xlink:href="/img/icons.svg#icon-spotify"></use>
+					</svg>
+					Spotify
+				</a>
+				<a href="https://music.apple.com/us/artist/j%C3%B6rg-eisfeld/1039919045" target="_blank" rel="noopener noreferrer">
+					<svg class="icon" aria-hidden="true">
+						<use xlink:href="/img/icons.svg?v=3#icon-apple-music"></use>
+					</svg>
+					Apple Music
+				</a>
+				<a href="https://amazon.de/music/player/albums/B0H1SFR4JH" target="_blank" rel="noopener noreferrer">
+					<svg class="icon" aria-hidden="true">
+						<use xlink:href="/img/icons.svg?v=3#icon-amazon-music"></use>
+					</svg>
+					Amazon Music
+				</a>
+			</div>
 		</div>
 
 		<div>


### PR DESCRIPTION
### Motivation
- Provide quick, well-formatted access to the album's YouTube, Spotify, Apple Music and Amazon Music pages directly below the cover image.

### Description
- Inserted a `div.social-links` block with four anchors and SVG `use` references into `jeisfeld/web/indiewelt/index.html` immediately below the cover image.
- Added CSS for `.social-links` and `.icon` to control layout, spacing, card-like link appearance, hover state, and icon sizing to match the existing dark theme.
- Added `rel="noopener noreferrer"` to external links that use `target="_blank"` for safer new-tab behavior.

### Testing
- No automated tests are present for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0748288cc48322aca3b9045d938d3d)