### PR TITLE
Replace audio nav text buttons with icon controls

### DIFF
--- a/jeisfeld/web/connylisa/index.html
+++ b/jeisfeld/web/connylisa/index.html
@@ -92,6 +92,13 @@ button:hover {
 	background: #333;
 }
 
+.icon-btn {
+	font-size: 18px;
+	line-height: 1;
+	min-width: 46px;
+	padding: 10px;
+}
+
 @media ( max-width : 760px) {
 	.wrap {
 		grid-template-columns: 1fr;
@@ -128,9 +135,9 @@ button:hover {
 			<audio id="player" controls preload="metadata"></audio>
 
 			<div style="display: flex; gap: 10px; margin: 10px 0 14px;">
-				<button id="prevBtn" type="button">⟨ Prev</button>
-				<button id="playPauseBtn" type="button">Play/Pause</button>
-				<button id="nextBtn" type="button">Next ⟩</button>
+				<button id="prevBtn" class="icon-btn" type="button" aria-label="Previous track" title="Previous track">⏮</button>
+				<button id="playPauseBtn" class="icon-btn" type="button" aria-label="Play or pause" title="Play/Pause">⏯</button>
+				<button id="nextBtn" class="icon-btn" type="button" aria-label="Next track" title="Next track">⏭</button>
 			</div>
 
 			<ul id="playlist"></ul>

--- a/jeisfeld/web/indiewelt/index.html
+++ b/jeisfeld/web/indiewelt/index.html
@@ -92,6 +92,13 @@ button:hover {
 	background: #333;
 }
 
+.icon-btn {
+	font-size: 18px;
+	line-height: 1;
+	min-width: 46px;
+	padding: 10px;
+}
+
 
 .social-links {
 	margin-top: 14px;
@@ -184,9 +191,9 @@ button:hover {
 			<audio id="player" controls preload="metadata"></audio>
 
 			<div style="display: flex; gap: 10px; margin: 10px 0 14px;">
-				<button id="prevBtn" type="button">⟨ Prev</button>
-				<button id="playPauseBtn" type="button">Play/Pause</button>
-				<button id="nextBtn" type="button">Next ⟩</button>
+				<button id="prevBtn" class="icon-btn" type="button" aria-label="Previous track" title="Previous track">⏮</button>
+				<button id="playPauseBtn" class="icon-btn" type="button" aria-label="Play or pause" title="Play/Pause">⏯</button>
+				<button id="nextBtn" class="icon-btn" type="button" aria-label="Next track" title="Next track">⏭</button>
 			</div>
 
 			<ul id="playlist"></ul>

--- a/jeisfeld/web/indiewelt/index.html
+++ b/jeisfeld/web/indiewelt/index.html
@@ -92,6 +92,35 @@ button:hover {
 	background: #333;
 }
 
+
+.social-links {
+	margin-top: 14px;
+	display: grid;
+	gap: 8px;
+}
+
+.social-links a {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 10px;
+	background: #161616;
+	border: 1px solid #2a2a2a;
+	border-radius: 10px;
+	color: #eee;
+	text-decoration: none;
+}
+
+.social-links a:hover {
+	background: #1d1d1d;
+}
+
+.icon {
+	width: 20px;
+	height: 20px;
+	fill: currentColor;
+}
+
 @media ( max-width : 760px) {
 	.wrap {
 		grid-template-columns: 1fr;
@@ -119,6 +148,33 @@ button:hover {
 	<div class="wrap">
 		<div>
 			<img src="cover.jpg" alt="Album cover" />
+
+			<div class="social-links">
+				<a href="https://www.youtube.com/watch?v=GWbdiFXUXbE&list=OLAK5uy_l1tE9U6aqs6wi1HobaYC0JN-ni1I1cHVc" target="_blank" rel="noopener noreferrer">
+					<svg class="icon" aria-hidden="true">
+						<use xlink:href="/img/icons.svg#icon-youtube"></use>
+					</svg>
+					Youtube
+				</a>
+				<a href="https://open.spotify.com/album/7GqxiaDlEQH6r72SIAENaR" target="_blank" rel="noopener noreferrer">
+					<svg class="icon" aria-hidden="true">
+						<use xlink:href="/img/icons.svg#icon-spotify"></use>
+					</svg>
+					Spotify
+				</a>
+				<a target="_blank" rel="noopener noreferrer">
+					<svg class="icon" aria-hidden="true">
+						<use xlink:href="/img/icons.svg?v=3#icon-apple-music"></use>
+					</svg>
+					Apple Music
+				</a>
+				<a href="https://amazon.de/music/player/albums/B0H1SFR4JH" target="_blank" rel="noopener noreferrer">
+					<svg class="icon" aria-hidden="true">
+						<use xlink:href="/img/icons.svg?v=3#icon-amazon-music"></use>
+					</svg>
+					Amazon Music
+				</a>
+			</div>
 		</div>
 
 		<div>

--- a/jeisfeld/web/jamsessions/index.html
+++ b/jeisfeld/web/jamsessions/index.html
@@ -92,6 +92,13 @@ button:hover {
 	background: #333;
 }
 
+.icon-btn {
+	font-size: 18px;
+	line-height: 1;
+	min-width: 46px;
+	padding: 10px;
+}
+
 @media ( max-width : 760px) {
 	.wrap {
 		grid-template-columns: 1fr;
@@ -128,9 +135,9 @@ button:hover {
 			<audio id="player" controls preload="metadata"></audio>
 
 			<div style="display: flex; gap: 10px; margin: 10px 0 14px;">
-				<button id="prevBtn" type="button">⟨ Prev</button>
-				<button id="playPauseBtn" type="button">Play/Pause</button>
-				<button id="nextBtn" type="button">Next ⟩</button>
+				<button id="prevBtn" class="icon-btn" type="button" aria-label="Previous track" title="Previous track">⏮</button>
+				<button id="playPauseBtn" class="icon-btn" type="button" aria-label="Play or pause" title="Play/Pause">⏯</button>
+				<button id="nextBtn" class="icon-btn" type="button" aria-label="Next track" title="Next track">⏭</button>
 			</div>
 
 			<ul id="playlist"></ul>


### PR DESCRIPTION
### Motivation
- Improve the player UI by replacing text labels with media-style glyphs while keeping existing JavaScript behavior and IDs intact.

### Description
- Replaced the `Prev`, `Play/Pause`, and `Next` button text with icon glyphs `⏮`, `⏯`, `⏭` in `jeisfeld/web/connylisa/index.html`, `jeisfeld/web/jamsessions/index.html`, and `jeisfeld/web/indiewelt/index.html`.
- Added a small `.icon-btn` CSS block on each page to harmonize sizing and spacing of the icon buttons.
- Preserved button `id`s so existing event listeners remain unchanged and added `aria-label` and `title` attributes for accessibility.

### Testing
- Located and inspected impacted files with `rg --files` and `sed`/`nl` checks, which completed successfully.
- Verified the exact changes with `git diff` and committed the updates with `git commit`, which succeeded.
- No automated unit tests were required for this static HTML/CSS UI tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07943c64888322abe8d45ce5a40e34)