### PR TITLE
Add album cover cross-links (indiewelt, wasser, jamsessions)

### DIFF
--- a/jeisfeld/web/indiewelt/index.html
+++ b/jeisfeld/web/indiewelt/index.html
@@ -99,6 +99,29 @@ button:hover {
 	padding: 10px;
 }
 
+.album-links {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
+	gap: 10px;
+	margin-top: 14px;
+}
+
+.album-links a {
+	display: block;
+	border-radius: 10px;
+}
+
+.album-links a:hover,
+.album-links a:focus-visible {
+	outline: 2px solid #eee;
+	outline-offset: 2px;
+}
+
+.album-links img {
+	display: block;
+	box-shadow: 0 4px 15px rgba(0, 0, 0, .4);
+}
+
 .social-links {
 	margin-top: 14px;
 	display: grid;
@@ -151,6 +174,15 @@ button:hover {
 	<div class="wrap">
 		<div>
 			<img src="cover.jpg" alt="Album cover" />
+
+			<nav class="album-links" aria-label="Other albums">
+				<a href="../jamsessions/" aria-label="Open Jam Sessions" title="Jam Sessions">
+					<img src="../jamsessions/cover.jpg" alt="Jam Sessions album cover" />
+				</a>
+				<a href="../wasser/" aria-label="Open Wasser" title="Wasser">
+					<img src="../wasser/cover.jpg" alt="Wasser album cover" />
+				</a>
+			</nav>
 
 			<div class="social-links">
 				<a href="https://www.youtube.com/watch?v=GWbdiFXUXbE&list=OLAK5uy_l1tE9U6aqs6wi1HobaYC0JN-ni1I1cHVc" target="_blank"

--- a/jeisfeld/web/jamsessions/index.html
+++ b/jeisfeld/web/jamsessions/index.html
@@ -99,6 +99,29 @@ button:hover {
 	padding: 10px;
 }
 
+.album-links {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
+	gap: 10px;
+	margin-top: 14px;
+}
+
+.album-links a {
+	display: block;
+	border-radius: 10px;
+}
+
+.album-links a:hover,
+.album-links a:focus-visible {
+	outline: 2px solid #eee;
+	outline-offset: 2px;
+}
+
+.album-links img {
+	display: block;
+	box-shadow: 0 4px 15px rgba(0, 0, 0, .4);
+}
+
 @media ( max-width : 760px) {
 	.wrap {
 		grid-template-columns: 1fr;
@@ -126,6 +149,15 @@ button:hover {
 	<div class="wrap">
 		<div>
 			<img src="cover.jpg" alt="Album cover" />
+
+			<nav class="album-links" aria-label="Other albums">
+				<a href="../indiewelt/" aria-label="Open In die Welt" title="In die Welt">
+					<img src="../indiewelt/cover.jpg" alt="In die Welt album cover" />
+				</a>
+				<a href="../wasser/" aria-label="Open Wasser" title="Wasser">
+					<img src="../wasser/cover.jpg" alt="Wasser album cover" />
+				</a>
+			</nav>
 		</div>
 
 		<div>

--- a/jeisfeld/web/wasser/index.html
+++ b/jeisfeld/web/wasser/index.html
@@ -99,6 +99,29 @@ button:hover {
 	padding: 10px;
 }
 
+.album-links {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
+	gap: 10px;
+	margin-top: 14px;
+}
+
+.album-links a {
+	display: block;
+	border-radius: 10px;
+}
+
+.album-links a:hover,
+.album-links a:focus-visible {
+	outline: 2px solid #eee;
+	outline-offset: 2px;
+}
+
+.album-links img {
+	display: block;
+	box-shadow: 0 4px 15px rgba(0, 0, 0, .4);
+}
+
 .social-links {
 	margin-top: 14px;
 	display: grid;
@@ -154,6 +177,15 @@ button:hover {
 	<div class="wrap">
 		<div>
 			<img src="cover.jpg" alt="Album cover" />
+
+			<nav class="album-links" aria-label="Other albums">
+				<a href="../jamsessions/" aria-label="Open Jam Sessions" title="Jam Sessions">
+					<img src="../jamsessions/cover.jpg" alt="Jam Sessions album cover" />
+				</a>
+				<a href="../indiewelt/" aria-label="Open In die Welt" title="In die Welt">
+					<img src="../indiewelt/cover.jpg" alt="In die Welt album cover" />
+				</a>
+			</nav>
 
 			<div class="social-links">
 				<a href="https://www.youtube.com/watch?v=3ub7k_aOFwo&list=OLAK5uy_mFvk4u5BsCX2UFr3cBlEB6SV9mccwmiGs" target="_blank"


### PR DESCRIPTION
### Motivation
- Provide quick navigation between album pages by adding small linked album-cover thumbnails beneath the main cover on each album page. 
- Keep the changes consistent with the existing dark card visual and layout, and make the UI easily extensible to additional albums later. 
- Ensure thumbnails are accessible (alt text, `aria-label`, `title` and focus-visible styling) and use only existing repository assets and simple CSS/HTML changes. 
- The requested `neuewellen` page/cover is not present in the repository, so the existing third album page `jamsessions` was used as the third cross-link target. 

### Description
- Added a new compact, responsive CSS block `.album-links` to each modified page to present thumbnails in a grid using `repeat(auto-fit, minmax(64px, 1fr))`. 
- Inserted a `<nav class="album-links" aria-label="Other albums">` beneath the main `<img src="cover.jpg">` on `jeisfeld/web/indiewelt/index.html`, `jeisfeld/web/wasser/index.html`, and `jeisfeld/web/jamsessions/index.html`, with thumbnail links to the other album folders via relative paths (e.g. `../wasser/cover.jpg`). 
- Thumbnails include `alt`, `title`, and `aria-label` attributes for accessibility and keyboard focus styling (`:focus-visible`) to match the existing design language (rounded corners and shadow). 
- No new files or external dependencies were added and visual/behavioral patterns from the existing pages were preserved. 

### Testing
- Parsed each modified HTML file with Python's `html.parser` to confirm valid markup, and the parse succeeded for all three pages. 
- Programmatically verified that each page contains a single `class="album-links"` and that every expected `href="../<target>/"` exists and the referenced `cover.jpg` files are present, and these assertions passed. 
- Ran `git diff --check` to detect whitespace or diff issues and it returned clean. 
- Attempted to locate a local browser executable (`chromium`/`chromium-browser`/`google-chrome`) to capture a screenshot, but none was available in the environment so visual rendering was not captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6798a593648322b8272040d8aac5af)