### PR TITLE
Add album cover cross-links to music pages

### DIFF
--- a/jeisfeld/web/indiewelt/index.html
+++ b/jeisfeld/web/indiewelt/index.html
@@ -27,6 +27,30 @@ img {
 	box-shadow: 0 8px 30px rgba(0, 0, 0, .4);
 }
 
+.album-links {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, 72px);
+	gap: 10px;
+	margin-top: 14px;
+}
+
+.album-links a {
+	display: block;
+	border-radius: 8px;
+}
+
+.album-links img {
+	display: block;
+	border-radius: 8px;
+	box-shadow: 0 4px 14px rgba(0, 0, 0, .4);
+	transition: opacity .2s;
+}
+
+.album-links a:hover img,
+.album-links a:focus-visible img {
+	opacity: .75;
+}
+
 h1 {
 	margin: 0 0 8px;
 	font-size: 24px;
@@ -151,6 +175,7 @@ button:hover {
 	<div class="wrap">
 		<div>
 			<img src="cover.jpg" alt="Album cover" />
+			<nav class="album-links" id="albumLinks" aria-label="Other albums"></nav>
 
 			<div class="social-links">
 				<a href="https://www.youtube.com/watch?v=GWbdiFXUXbE&list=OLAK5uy_l1tE9U6aqs6wi1HobaYC0JN-ni1I1cHVc" target="_blank"
@@ -210,6 +235,26 @@ button:hover {
 	</div>
 
 	<script>
+    // Add future albums here; the current album is omitted automatically.
+	const albums = [
+	  { slug: "indiewelt", title: "In die Welt" },
+	  { slug: "wasser", title: "Wasser" },
+	  { slug: "neuewellen", title: "Neue Wellen" },
+	];
+	const currentAlbum = "indiewelt";
+	const albumLinks = document.getElementById("albumLinks");
+	albums.filter((album) => album.slug !== currentAlbum).forEach((album) => {
+	  const link = document.createElement("a");
+	  const cover = document.createElement("img");
+	  link.href = `/${album.slug}/`;
+	  link.title = album.title;
+	  link.setAttribute("aria-label", `Open album ${album.title}`);
+	  cover.src = `/${album.slug}/cover.jpg`;
+	  cover.alt = `${album.title} album cover`;
+	  link.appendChild(cover);
+	  albumLinks.appendChild(link);
+	});
+
     // 1) Edit this list to match your MP3 files
 	const tracks = [
 	  { title: "In mir", file: "tracks/01 In mir.mp3" },

--- a/jeisfeld/web/neuewellen/index.html
+++ b/jeisfeld/web/neuewellen/index.html
@@ -27,6 +27,30 @@ img {
 	box-shadow: 0 8px 30px rgba(0, 0, 0, .4);
 }
 
+.album-links {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, 72px);
+	gap: 10px;
+	margin-top: 14px;
+}
+
+.album-links a {
+	display: block;
+	border-radius: 8px;
+}
+
+.album-links img {
+	display: block;
+	border-radius: 8px;
+	box-shadow: 0 4px 14px rgba(0, 0, 0, .4);
+	transition: opacity .2s;
+}
+
+.album-links a:hover img,
+.album-links a:focus-visible img {
+	opacity: .75;
+}
+
 h1 {
 	margin: 0 0 8px;
 	font-size: 24px;
@@ -151,6 +175,7 @@ button:hover {
 	<div class="wrap">
 		<div>
 			<img src="cover.jpg" alt="Album cover" />
+			<nav class="album-links" id="albumLinks" aria-label="Other albums"></nav>
 		</div>
 
 		<div>
@@ -170,6 +195,26 @@ button:hover {
 	</div>
 
 	<script>
+    // Add future albums here; the current album is omitted automatically.
+	const albums = [
+	  { slug: "indiewelt", title: "In die Welt" },
+	  { slug: "wasser", title: "Wasser" },
+	  { slug: "neuewellen", title: "Neue Wellen" },
+	];
+	const currentAlbum = "neuewellen";
+	const albumLinks = document.getElementById("albumLinks");
+	albums.filter((album) => album.slug !== currentAlbum).forEach((album) => {
+	  const link = document.createElement("a");
+	  const cover = document.createElement("img");
+	  link.href = `/${album.slug}/`;
+	  link.title = album.title;
+	  link.setAttribute("aria-label", `Open album ${album.title}`);
+	  cover.src = `/${album.slug}/cover.jpg`;
+	  cover.alt = `${album.title} album cover`;
+	  link.appendChild(cover);
+	  albumLinks.appendChild(link);
+	});
+
     // 1) Edit this list to match your MP3 files
 	const tracks = [
 	  { title: "Dankbar für alles", file: "tracks/01 Dankbar für alles.mp3" },

--- a/jeisfeld/web/wasser/index.html
+++ b/jeisfeld/web/wasser/index.html
@@ -27,6 +27,30 @@ img {
 	box-shadow: 0 8px 30px rgba(0, 0, 0, .4);
 }
 
+.album-links {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, 72px);
+	gap: 10px;
+	margin-top: 14px;
+}
+
+.album-links a {
+	display: block;
+	border-radius: 8px;
+}
+
+.album-links img {
+	display: block;
+	border-radius: 8px;
+	box-shadow: 0 4px 14px rgba(0, 0, 0, .4);
+	transition: opacity .2s;
+}
+
+.album-links a:hover img,
+.album-links a:focus-visible img {
+	opacity: .75;
+}
+
 h1 {
 	margin: 0 0 8px;
 	font-size: 24px;
@@ -154,6 +178,7 @@ button:hover {
 	<div class="wrap">
 		<div>
 			<img src="cover.jpg" alt="Album cover" />
+			<nav class="album-links" id="albumLinks" aria-label="Other albums"></nav>
 
 			<div class="social-links">
 				<a href="https://www.youtube.com/watch?v=3ub7k_aOFwo&list=OLAK5uy_mFvk4u5BsCX2UFr3cBlEB6SV9mccwmiGs" target="_blank"
@@ -213,6 +238,26 @@ button:hover {
 	</div>
 
 	<script>
+    // Add future albums here; the current album is omitted automatically.
+	const albums = [
+	  { slug: "indiewelt", title: "In die Welt" },
+	  { slug: "wasser", title: "Wasser" },
+	  { slug: "neuewellen", title: "Neue Wellen" },
+	];
+	const currentAlbum = "wasser";
+	const albumLinks = document.getElementById("albumLinks");
+	albums.filter((album) => album.slug !== currentAlbum).forEach((album) => {
+	  const link = document.createElement("a");
+	  const cover = document.createElement("img");
+	  link.href = `/${album.slug}/`;
+	  link.title = album.title;
+	  link.setAttribute("aria-label", `Open album ${album.title}`);
+	  cover.src = `/${album.slug}/cover.jpg`;
+	  cover.alt = `${album.title} album cover`;
+	  link.appendChild(cover);
+	  albumLinks.appendChild(link);
+	});
+
     // 1) Edit this list to match your MP3 files
 	const tracks = [
 	  { title: "Ich reise zu mir selbst", file: "tracks/01 Ich reise zu mir selbst.mp3" },


### PR DESCRIPTION
### Motivation

- Provide quick navigation between the three album pages by showing small linked album covers under the main cover. 
- Implement a simple, extensible mechanism so additional albums can be added later without changing page structure.

### Description

- Added compact album-cover navigation UI and styles with a new `.album-links` rule and small, rounded cover images inserted below the main cover on each page.
- Inserted an accessible `<nav class="album-links" id="albumLinks" aria-label="Other albums">` placeholder into `jeisfeld/web/indiewelt/index.html`, `jeisfeld/web/wasser/index.html`, and `jeisfeld/web/neuewellen/index.html`.
- Added inline JavaScript on each page that defines a single `albums` metadata list, omits the current page, and programmatically creates linked `img` elements pointing at `/<slug>/cover.jpg` with `title` and `aria-label` attributes for accessibility.
- Kept everything inline to match the existing design (no new files), preserved current visual style, and made the layout responsive.

### Testing

- Parsed each updated HTML file with Python's `html.parser` successfully (no parse errors).
- Extracted inline scripts and validated the JS syntax using `node --check` successfully.
- Verified cover assets exist and are non-empty with a shell asset check (`test -s jeisfeld/web/<album>/cover.jpg`) successfully.
- Ran `git diff --check` and other repository checks; they reported no blocking issues, but automated screenshot generation via `npx --yes playwright@1.54.1 install chromium` failed due to the environment npm registry returning HTTP 403 so visual screenshots were not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6799dd02ac832296eb0b672dd8df17)