### PR TITLE
Refactor Jeisfeld album pages to use shared assets

### DIFF
--- a/jeisfeld/web/css/album-player.css
+++ b/jeisfeld/web/css/album-player.css
@@ -1,0 +1,170 @@
+body {
+	font-family: system-ui, sans-serif;
+	margin: 0;
+	background: #111;
+	color: #eee;
+}
+
+.wrap {
+	max-width: 900px;
+	margin: 0 auto;
+	padding: 24px;
+	display: grid;
+	gap: 24px;
+	grid-template-columns: 280px 1fr;
+}
+
+img {
+	width: 100%;
+	border-radius: 12px;
+	box-shadow: 0 8px 30px rgba(0, 0, 0, .4);
+}
+
+.album-links {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, 72px);
+	gap: 10px;
+	margin-top: 14px;
+}
+
+.album-links a {
+	display: block;
+	border-radius: 8px;
+}
+
+.album-links img {
+	display: block;
+	border-radius: 8px;
+	box-shadow: 0 4px 14px rgba(0, 0, 0, .4);
+	transition: opacity .2s;
+}
+
+.album-links a:hover img,
+.album-links a:focus-visible img {
+	opacity: .75;
+}
+
+h1 {
+	margin: 0 0 8px;
+	font-size: 24px;
+}
+
+audio {
+	width: 100%;
+	margin: 12px 0 8px;
+}
+
+ul {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	border-radius: 12px;
+	overflow: hidden;
+	border: 1px solid #2a2a2a;
+}
+
+li {
+	display: flex;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 3px 14px;
+	cursor: pointer;
+	background: #161616;
+	border-top: 1px solid #2a2a2a;
+}
+
+li:first-child {
+	border-top: 0;
+}
+
+li:hover {
+	background: #1d1d1d;
+}
+
+li.active {
+	background: #2a2a2a;
+}
+
+.meta {
+	opacity: .7;
+	font-size: 13px;
+}
+
+.row {
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
+}
+
+button {
+	background: #2a2a2a;
+	color: #eee;
+	border: 1px solid #3a3a3a;
+	padding: 10px 12px;
+	border-radius: 10px;
+	cursor: pointer;
+}
+
+button:hover {
+	background: #333;
+}
+
+.icon-btn {
+	font-size: 18px;
+	line-height: 1;
+	min-width: 46px;
+	padding: 10px;
+}
+
+.social-links {
+	margin-top: 14px;
+	display: grid;
+	gap: 8px;
+}
+
+.social-links a {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 10px;
+	background: #161616;
+	border: 1px solid #2a2a2a;
+	border-radius: 10px;
+	color: #eee;
+	text-decoration: none;
+}
+
+.social-links a:hover {
+	background: #1d1d1d;
+}
+
+.icon {
+	width: 20px;
+	height: 20px;
+	fill: currentColor;
+}
+
+@media ( max-width : 760px) {
+	.wrap {
+		grid-template-columns: 1fr;
+	}
+}
+
+@media ( max-width : 480px) {
+	.wrap {
+		padding: 16px;
+	}
+	li {
+		padding: 3px 8px;
+	}
+	.row {
+		font-size: 14px;
+		gap: 6px;
+	}
+}
+
+.player-controls {
+	display: flex;
+	gap: 10px;
+	margin: 10px 0 14px;
+}

--- a/jeisfeld/web/indiewelt/index.html
+++ b/jeisfeld/web/indiewelt/index.html
@@ -4,172 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Solea lebt! - In die Welt</title>
-<style>
-body {
-	font-family: system-ui, sans-serif;
-	margin: 0;
-	background: #111;
-	color: #eee;
-}
-
-.wrap {
-	max-width: 900px;
-	margin: 0 auto;
-	padding: 24px;
-	display: grid;
-	gap: 24px;
-	grid-template-columns: 280px 1fr;
-}
-
-img {
-	width: 100%;
-	border-radius: 12px;
-	box-shadow: 0 8px 30px rgba(0, 0, 0, .4);
-}
-
-.album-links {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, 72px);
-	gap: 10px;
-	margin-top: 14px;
-}
-
-.album-links a {
-	display: block;
-	border-radius: 8px;
-}
-
-.album-links img {
-	display: block;
-	border-radius: 8px;
-	box-shadow: 0 4px 14px rgba(0, 0, 0, .4);
-	transition: opacity .2s;
-}
-
-.album-links a:hover img,
-.album-links a:focus-visible img {
-	opacity: .75;
-}
-
-h1 {
-	margin: 0 0 8px;
-	font-size: 24px;
-}
-
-audio {
-	width: 100%;
-	margin: 12px 0 8px;
-}
-
-ul {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-	border-radius: 12px;
-	overflow: hidden;
-	border: 1px solid #2a2a2a;
-}
-
-li {
-	display: flex;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 3px 14px;
-	cursor: pointer;
-	background: #161616;
-	border-top: 1px solid #2a2a2a;
-}
-
-li:first-child {
-	border-top: 0;
-}
-
-li:hover {
-	background: #1d1d1d;
-}
-
-li.active {
-	background: #2a2a2a;
-}
-
-.meta {
-	opacity: .7;
-	font-size: 13px;
-}
-
-.row {
-	display: flex;
-	align-items: baseline;
-	gap: 10px;
-}
-
-button {
-	background: #2a2a2a;
-	color: #eee;
-	border: 1px solid #3a3a3a;
-	padding: 10px 12px;
-	border-radius: 10px;
-	cursor: pointer;
-}
-
-button:hover {
-	background: #333;
-}
-
-.icon-btn {
-	font-size: 18px;
-	line-height: 1;
-	min-width: 46px;
-	padding: 10px;
-}
-
-.social-links {
-	margin-top: 14px;
-	display: grid;
-	gap: 8px;
-}
-
-.social-links a {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 8px 10px;
-	background: #161616;
-	border: 1px solid #2a2a2a;
-	border-radius: 10px;
-	color: #eee;
-	text-decoration: none;
-}
-
-.social-links a:hover {
-	background: #1d1d1d;
-}
-
-.icon {
-	width: 20px;
-	height: 20px;
-	fill: currentColor;
-}
-
-@media ( max-width : 760px) {
-	.wrap {
-		grid-template-columns: 1fr;
-	}
-}
-
-@media ( max-width : 480px) {
-	.wrap {
-		padding: 16px;
-	}
-	li {
-		padding: 3px 8px;
-	}
-	.row {
-		font-size: 14px;
-		gap: 6px;
-	}
-}
-</style>
+<link rel="stylesheet" href="/css/album-player.css" />
 </head>
 <body>
 	<div class="wrap">
@@ -224,7 +59,7 @@ button:hover {
 
 			<audio id="player" controls preload="metadata"></audio>
 
-			<div style="display: flex; gap: 10px; margin: 10px 0 14px;">
+			<div class="player-controls">
 				<button id="prevBtn" class="icon-btn" type="button" aria-label="Previous track" title="Previous track">⏮</button>
 				<button id="playPauseBtn" class="icon-btn" type="button" aria-label="Play or pause" title="Play/Pause">⏯</button>
 				<button id="nextBtn" class="icon-btn" type="button" aria-label="Next track" title="Next track">⏭</button>
@@ -235,25 +70,8 @@ button:hover {
 	</div>
 
 	<script>
-    // Add future albums here; the current album is omitted automatically.
-	const albums = [
-	  { slug: "indiewelt", title: "In die Welt" },
-	  { slug: "wasser", title: "Wasser" },
-	  { slug: "neuewellen", title: "Neue Wellen" },
-	];
 	const currentAlbum = "indiewelt";
-	const albumLinks = document.getElementById("albumLinks");
-	albums.filter((album) => album.slug !== currentAlbum).forEach((album) => {
-	  const link = document.createElement("a");
-	  const cover = document.createElement("img");
-	  link.href = `/${album.slug}/`;
-	  link.title = album.title;
-	  link.setAttribute("aria-label", `Open album ${album.title}`);
-	  cover.src = `/${album.slug}/cover.jpg`;
-	  cover.alt = `${album.title} album cover`;
-	  link.appendChild(cover);
-	  albumLinks.appendChild(link);
-	});
+
 
     // 1) Edit this list to match your MP3 files
 	const tracks = [
@@ -275,97 +93,7 @@ button:hover {
 	  { title: "Schmelzend", file: "tracks/16 Schmelzend.mp3" },
 	  { title: "Meine Wahrheit", file: "tracks/17 Meine Wahrheit.mp3" },
 	];
-
-
-    const player = document.getElementById("player");
-    const playlistEl = document.getElementById("playlist");
-    const nowPlayingEl = document.getElementById("nowPlaying");
-    const prevBtn = document.getElementById("prevBtn");
-    const nextBtn = document.getElementById("nextBtn");
-    const playPauseBtn = document.getElementById("playPauseBtn");
-
-    let currentIndex = 0;
-
-    function renderPlaylist() {
-      playlistEl.innerHTML = "";
-      tracks.forEach((t, i) => {
-        const li = document.createElement("li");
-        li.dataset.index = i;
-
-        const left = document.createElement("div");
-        left.className = "row";
-        left.innerHTML = `<strong>${String(i + 1).padStart(2, "0")}.</strong> <span>${t.title}</span>`;
-
-        const right = document.createElement("div");
-        right.className = "meta";
-        right.textContent = "▶";
-
-        li.appendChild(left);
-        li.appendChild(right);
-
-        li.addEventListener("click", () => playIndex(i, true));
-        playlistEl.appendChild(li);
-      });
-      highlightActive();
-    }
-
-    function highlightActive() {
-      [...playlistEl.children].forEach((li) => li.classList.remove("active"));
-      const active = playlistEl.children[currentIndex];
-      if (active) active.classList.add("active");
-    }
-
-    function setNowPlaying(text) {
-      nowPlayingEl.textContent = text;
-    }
-
-    function playIndex(index, autoplay = false) {
-      if (index < 0 || index >= tracks.length) return;
-      currentIndex = index;
-
-      player.src = tracks[currentIndex].file;
-      player.load();
-
-      highlightActive();
-      setNowPlaying(`Selected: ${tracks[currentIndex].title}`);
-
-      if (autoplay) {
-        // Note: some browsers require a user gesture before audio playback.
-        player.play().then(() => {
-          setNowPlaying(`Playing: ${tracks[currentIndex].title}`);
-        }).catch(() => {
-          setNowPlaying(`Ready to play: ${tracks[currentIndex].title} (press Play)`);
-        });
-      }
-    }
-
-    function nextTrack() {
-      const next = (currentIndex + 1) % tracks.length; // loop back to start
-      playIndex(next, true);
-    }
-
-    function prevTrack() {
-      const prev = (currentIndex - 1 + tracks.length) % tracks.length;
-      playIndex(prev, true);
-    }
-
-    // Auto-advance when a song ends
-    player.addEventListener("ended", nextTrack);
-
-    // Update UI on play/pause
-    player.addEventListener("play", () => setNowPlaying(`Playing: ${tracks[currentIndex].title}`));
-    player.addEventListener("pause", () => setNowPlaying(`Paused: ${tracks[currentIndex].title}`));
-
-    prevBtn.addEventListener("click", prevTrack);
-    nextBtn.addEventListener("click", nextTrack);
-    playPauseBtn.addEventListener("click", () => {
-      if (player.paused) player.play();
-      else player.pause();
-    });
-
-    // Init
-    renderPlaylist();
-    playIndex(0, false);
-  </script>
+	</script>
+	<script src="/js/album-player.js"></script>
 </body>
 </html>

--- a/jeisfeld/web/jamsessions/index.html
+++ b/jeisfeld/web/jamsessions/index.html
@@ -4,123 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Jörg Eisfeld - Jam Sessions</title>
-<style>
-body {
-	font-family: system-ui, sans-serif;
-	margin: 0;
-	background: #111;
-	color: #eee;
-}
-
-.wrap {
-	max-width: 900px;
-	margin: 0 auto;
-	padding: 24px;
-	display: grid;
-	gap: 24px;
-	grid-template-columns: 280px 1fr;
-}
-
-img {
-	width: 100%;
-	border-radius: 12px;
-	box-shadow: 0 8px 30px rgba(0, 0, 0, .4);
-}
-
-h1 {
-	margin: 0 0 8px;
-	font-size: 24px;
-}
-
-audio {
-	width: 100%;
-	margin: 12px 0 8px;
-}
-
-ul {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-	border-radius: 12px;
-	overflow: hidden;
-	border: 1px solid #2a2a2a;
-}
-
-li {
-	display: flex;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 3px 14px;
-	cursor: pointer;
-	background: #161616;
-	border-top: 1px solid #2a2a2a;
-}
-
-li:first-child {
-	border-top: 0;
-}
-
-li:hover {
-	background: #1d1d1d;
-}
-
-li.active {
-	background: #2a2a2a;
-}
-
-.meta {
-	opacity: .7;
-	font-size: 13px;
-}
-
-.row {
-	display: flex;
-	align-items: baseline;
-	gap: 10px;
-}
-
-button {
-	background: #2a2a2a;
-	color: #eee;
-	border: 1px solid #3a3a3a;
-	padding: 10px 12px;
-	border-radius: 10px;
-	cursor: pointer;
-}
-
-button:hover {
-	background: #333;
-}
-
-.icon-btn {
-	font-size: 18px;
-	line-height: 1;
-	min-width: 46px;
-	padding: 10px;
-}
-
-@media ( max-width : 760px) {
-	.wrap {
-		grid-template-columns: 1fr;
-	}
-}
-
-
-@media ( max-width : 480px) {
-	.wrap {
-		padding: 16px;
-	}
-
-	li {
-		padding: 3px 8px;
-	}
-
-	.row {
-		font-size: 14px;
-		gap: 6px;
-	}
-}
-</style>
+<link rel="stylesheet" href="/css/album-player.css" />
 </head>
 <body>
 	<div class="wrap">
@@ -134,7 +18,7 @@ button:hover {
 
 			<audio id="player" controls preload="metadata"></audio>
 
-			<div style="display: flex; gap: 10px; margin: 10px 0 14px;">
+			<div class="player-controls">
 				<button id="prevBtn" class="icon-btn" type="button" aria-label="Previous track" title="Previous track">⏮</button>
 				<button id="playPauseBtn" class="icon-btn" type="button" aria-label="Play or pause" title="Play/Pause">⏯</button>
 				<button id="nextBtn" class="icon-btn" type="button" aria-label="Next track" title="Next track">⏭</button>
@@ -220,97 +104,7 @@ button:hover {
 	  { title: "Liebe Tanzen 20260613 2: Morpheus", file: "tracks/53 Liebe Tanzen 20260613 2_ Morpheus.mp3" },
 	  { title: "Liebe Tanzen 20260613 3: Shadow Crunch Guitar", file: "tracks/54 Liebe Tanzen 20260613 3_ Shadow C.mp3" },
 	  ];
-
-
-    const player = document.getElementById("player");
-    const playlistEl = document.getElementById("playlist");
-    const nowPlayingEl = document.getElementById("nowPlaying");
-    const prevBtn = document.getElementById("prevBtn");
-    const nextBtn = document.getElementById("nextBtn");
-    const playPauseBtn = document.getElementById("playPauseBtn");
-
-    let currentIndex = 0;
-
-    function renderPlaylist() {
-      playlistEl.innerHTML = "";
-      tracks.forEach((t, i) => {
-        const li = document.createElement("li");
-        li.dataset.index = i;
-
-        const left = document.createElement("div");
-        left.className = "row";
-        left.innerHTML = `<strong>${String(i + 1).padStart(2, "0")}.</strong> <span>${t.title}</span>`;
-
-        const right = document.createElement("div");
-        right.className = "meta";
-        right.textContent = "▶";
-
-        li.appendChild(left);
-        li.appendChild(right);
-
-        li.addEventListener("click", () => playIndex(i, true));
-        playlistEl.appendChild(li);
-      });
-      highlightActive();
-    }
-
-    function highlightActive() {
-      [...playlistEl.children].forEach((li) => li.classList.remove("active"));
-      const active = playlistEl.children[currentIndex];
-      if (active) active.classList.add("active");
-    }
-
-    function setNowPlaying(text) {
-      nowPlayingEl.textContent = text;
-    }
-
-    function playIndex(index, autoplay = false) {
-      if (index < 0 || index >= tracks.length) return;
-      currentIndex = index;
-
-      player.src = tracks[currentIndex].file;
-      player.load();
-
-      highlightActive();
-      setNowPlaying(`Selected: ${tracks[currentIndex].title}`);
-
-      if (autoplay) {
-        // Note: some browsers require a user gesture before audio playback.
-        player.play().then(() => {
-          setNowPlaying(`Playing: ${tracks[currentIndex].title}`);
-        }).catch(() => {
-          setNowPlaying(`Ready to play: ${tracks[currentIndex].title} (press Play)`);
-        });
-      }
-    }
-
-    function nextTrack() {
-      const next = (currentIndex + 1) % tracks.length; // loop back to start
-      playIndex(next, true);
-    }
-
-    function prevTrack() {
-      const prev = (currentIndex - 1 + tracks.length) % tracks.length;
-      playIndex(prev, true);
-    }
-
-    // Auto-advance when a song ends
-    player.addEventListener("ended", nextTrack);
-
-    // Update UI on play/pause
-    player.addEventListener("play", () => setNowPlaying(`Playing: ${tracks[currentIndex].title}`));
-    player.addEventListener("pause", () => setNowPlaying(`Paused: ${tracks[currentIndex].title}`));
-
-    prevBtn.addEventListener("click", prevTrack);
-    nextBtn.addEventListener("click", nextTrack);
-    playPauseBtn.addEventListener("click", () => {
-      if (player.paused) player.play();
-      else player.pause();
-    });
-
-    // Init
-    renderPlaylist();
-    playIndex(0, false);
-  </script>
+	</script>
+	<script src="/js/album-player.js"></script>
 </body>
 </html>

--- a/jeisfeld/web/js/album-player.js
+++ b/jeisfeld/web/js/album-player.js
@@ -1,0 +1,98 @@
+const albums = [
+  { slug: "indiewelt", title: "In die Welt" },
+  { slug: "wasser", title: "Wasser" },
+  { slug: "neuewellen", title: "Neue Wellen" },
+];
+
+const albumLinks = document.getElementById("albumLinks");
+if (albumLinks) {
+  albums.filter((album) => album.slug !== currentAlbum).forEach((album) => {
+    const link = document.createElement("a");
+    const cover = document.createElement("img");
+    link.href = `/${album.slug}/`;
+    link.title = album.title;
+    link.setAttribute("aria-label", `Open album ${album.title}`);
+    cover.src = `/${album.slug}/cover.jpg`;
+    cover.alt = `${album.title} album cover`;
+    link.appendChild(cover);
+    albumLinks.appendChild(link);
+  });
+}
+
+const player = document.getElementById("player");
+const playlistEl = document.getElementById("playlist");
+const nowPlayingEl = document.getElementById("nowPlaying");
+const prevBtn = document.getElementById("prevBtn");
+const nextBtn = document.getElementById("nextBtn");
+const playPauseBtn = document.getElementById("playPauseBtn");
+let currentIndex = 0;
+
+function highlightActive() {
+  [...playlistEl.children].forEach((item) => item.classList.remove("active"));
+  const active = playlistEl.children[currentIndex];
+  if (active) active.classList.add("active");
+}
+
+function setNowPlaying(text) {
+  nowPlayingEl.textContent = text;
+}
+
+function playIndex(index, autoplay = false) {
+  if (index < 0 || index >= tracks.length) return;
+  currentIndex = index;
+  player.src = tracks[currentIndex].file;
+  player.load();
+  highlightActive();
+  setNowPlaying(`Selected: ${tracks[currentIndex].title}`);
+
+  if (autoplay) {
+    player.play().then(() => {
+      setNowPlaying(`Playing: ${tracks[currentIndex].title}`);
+    }).catch(() => {
+      setNowPlaying(`Ready to play: ${tracks[currentIndex].title} (press Play)`);
+    });
+  }
+}
+
+function renderPlaylist() {
+  playlistEl.innerHTML = "";
+  tracks.forEach((track, index) => {
+    const item = document.createElement("li");
+    item.dataset.index = index;
+
+    const title = document.createElement("div");
+    title.className = "row";
+    title.innerHTML = `<strong>${String(index + 1).padStart(2, "0")}.</strong> <span>${track.title}</span>`;
+
+    const playIcon = document.createElement("div");
+    playIcon.className = "meta";
+    playIcon.textContent = "▶";
+
+    item.appendChild(title);
+    item.appendChild(playIcon);
+    item.addEventListener("click", () => playIndex(index, true));
+    playlistEl.appendChild(item);
+  });
+  highlightActive();
+}
+
+function nextTrack() {
+  playIndex((currentIndex + 1) % tracks.length, true);
+}
+
+function prevTrack() {
+  playIndex((currentIndex - 1 + tracks.length) % tracks.length, true);
+}
+
+player.addEventListener("ended", nextTrack);
+player.addEventListener("play", () => setNowPlaying(`Playing: ${tracks[currentIndex].title}`));
+player.addEventListener("pause", () => setNowPlaying(`Paused: ${tracks[currentIndex].title}`));
+prevBtn.addEventListener("click", prevTrack);
+nextBtn.addEventListener("click", nextTrack);
+playPauseBtn.addEventListener("click", () => {
+  if (player.paused) player.play();
+  else player.pause();
+});
+
+renderPlaylist();
+playIndex(0);

--- a/jeisfeld/web/neuewellen/index.html
+++ b/jeisfeld/web/neuewellen/index.html
@@ -4,172 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Solea lebt! - Neue Wellen</title>
-<style>
-body {
-	font-family: system-ui, sans-serif;
-	margin: 0;
-	background: #111;
-	color: #eee;
-}
-
-.wrap {
-	max-width: 900px;
-	margin: 0 auto;
-	padding: 24px;
-	display: grid;
-	gap: 24px;
-	grid-template-columns: 280px 1fr;
-}
-
-img {
-	width: 100%;
-	border-radius: 12px;
-	box-shadow: 0 8px 30px rgba(0, 0, 0, .4);
-}
-
-.album-links {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, 72px);
-	gap: 10px;
-	margin-top: 14px;
-}
-
-.album-links a {
-	display: block;
-	border-radius: 8px;
-}
-
-.album-links img {
-	display: block;
-	border-radius: 8px;
-	box-shadow: 0 4px 14px rgba(0, 0, 0, .4);
-	transition: opacity .2s;
-}
-
-.album-links a:hover img,
-.album-links a:focus-visible img {
-	opacity: .75;
-}
-
-h1 {
-	margin: 0 0 8px;
-	font-size: 24px;
-}
-
-audio {
-	width: 100%;
-	margin: 12px 0 8px;
-}
-
-ul {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-	border-radius: 12px;
-	overflow: hidden;
-	border: 1px solid #2a2a2a;
-}
-
-li {
-	display: flex;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 3px 14px;
-	cursor: pointer;
-	background: #161616;
-	border-top: 1px solid #2a2a2a;
-}
-
-li:first-child {
-	border-top: 0;
-}
-
-li:hover {
-	background: #1d1d1d;
-}
-
-li.active {
-	background: #2a2a2a;
-}
-
-.meta {
-	opacity: .7;
-	font-size: 13px;
-}
-
-.row {
-	display: flex;
-	align-items: baseline;
-	gap: 10px;
-}
-
-button {
-	background: #2a2a2a;
-	color: #eee;
-	border: 1px solid #3a3a3a;
-	padding: 10px 12px;
-	border-radius: 10px;
-	cursor: pointer;
-}
-
-button:hover {
-	background: #333;
-}
-
-.icon-btn {
-	font-size: 18px;
-	line-height: 1;
-	min-width: 46px;
-	padding: 10px;
-}
-
-.social-links {
-	margin-top: 14px;
-	display: grid;
-	gap: 8px;
-}
-
-.social-links a {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 8px 10px;
-	background: #161616;
-	border: 1px solid #2a2a2a;
-	border-radius: 10px;
-	color: #eee;
-	text-decoration: none;
-}
-
-.social-links a:hover {
-	background: #1d1d1d;
-}
-
-.icon {
-	width: 20px;
-	height: 20px;
-	fill: currentColor;
-}
-
-@media ( max-width : 760px) {
-	.wrap {
-		grid-template-columns: 1fr;
-	}
-}
-
-@media ( max-width : 480px) {
-	.wrap {
-		padding: 16px;
-	}
-	li {
-		padding: 3px 8px;
-	}
-	.row {
-		font-size: 14px;
-		gap: 6px;
-	}
-}
-</style>
+<link rel="stylesheet" href="/css/album-player.css" />
 </head>
 <body>
 	<div class="wrap">
@@ -184,7 +19,7 @@ button:hover {
 
 			<audio id="player" controls preload="metadata"></audio>
 
-			<div style="display: flex; gap: 10px; margin: 10px 0 14px;">
+			<div class="player-controls">
 				<button id="prevBtn" class="icon-btn" type="button" aria-label="Previous track" title="Previous track">⏮</button>
 				<button id="playPauseBtn" class="icon-btn" type="button" aria-label="Play or pause" title="Play/Pause">⏯</button>
 				<button id="nextBtn" class="icon-btn" type="button" aria-label="Next track" title="Next track">⏭</button>
@@ -195,25 +30,8 @@ button:hover {
 	</div>
 
 	<script>
-    // Add future albums here; the current album is omitted automatically.
-	const albums = [
-	  { slug: "indiewelt", title: "In die Welt" },
-	  { slug: "wasser", title: "Wasser" },
-	  { slug: "neuewellen", title: "Neue Wellen" },
-	];
 	const currentAlbum = "neuewellen";
-	const albumLinks = document.getElementById("albumLinks");
-	albums.filter((album) => album.slug !== currentAlbum).forEach((album) => {
-	  const link = document.createElement("a");
-	  const cover = document.createElement("img");
-	  link.href = `/${album.slug}/`;
-	  link.title = album.title;
-	  link.setAttribute("aria-label", `Open album ${album.title}`);
-	  cover.src = `/${album.slug}/cover.jpg`;
-	  cover.alt = `${album.title} album cover`;
-	  link.appendChild(cover);
-	  albumLinks.appendChild(link);
-	});
+
 
     // 1) Edit this list to match your MP3 files
 	const tracks = [
@@ -224,97 +42,7 @@ button:hover {
 	  { title: "Fluss des Lebens", file: "tracks/05 Fluss des Lebens.mp3" },
 	  { title: "Wenn ich mir einen Mann backen könnte", file: "tracks/06 Wenn ich mir einen Mann backen kö.mp3" },
 	];
-
-
-    const player = document.getElementById("player");
-    const playlistEl = document.getElementById("playlist");
-    const nowPlayingEl = document.getElementById("nowPlaying");
-    const prevBtn = document.getElementById("prevBtn");
-    const nextBtn = document.getElementById("nextBtn");
-    const playPauseBtn = document.getElementById("playPauseBtn");
-
-    let currentIndex = 0;
-
-    function renderPlaylist() {
-      playlistEl.innerHTML = "";
-      tracks.forEach((t, i) => {
-        const li = document.createElement("li");
-        li.dataset.index = i;
-
-        const left = document.createElement("div");
-        left.className = "row";
-        left.innerHTML = `<strong>${String(i + 1).padStart(2, "0")}.</strong> <span>${t.title}</span>`;
-
-        const right = document.createElement("div");
-        right.className = "meta";
-        right.textContent = "▶";
-
-        li.appendChild(left);
-        li.appendChild(right);
-
-        li.addEventListener("click", () => playIndex(i, true));
-        playlistEl.appendChild(li);
-      });
-      highlightActive();
-    }
-
-    function highlightActive() {
-      [...playlistEl.children].forEach((li) => li.classList.remove("active"));
-      const active = playlistEl.children[currentIndex];
-      if (active) active.classList.add("active");
-    }
-
-    function setNowPlaying(text) {
-      nowPlayingEl.textContent = text;
-    }
-
-    function playIndex(index, autoplay = false) {
-      if (index < 0 || index >= tracks.length) return;
-      currentIndex = index;
-
-      player.src = tracks[currentIndex].file;
-      player.load();
-
-      highlightActive();
-      setNowPlaying(`Selected: ${tracks[currentIndex].title}`);
-
-      if (autoplay) {
-        // Note: some browsers require a user gesture before audio playback.
-        player.play().then(() => {
-          setNowPlaying(`Playing: ${tracks[currentIndex].title}`);
-        }).catch(() => {
-          setNowPlaying(`Ready to play: ${tracks[currentIndex].title} (press Play)`);
-        });
-      }
-    }
-
-    function nextTrack() {
-      const next = (currentIndex + 1) % tracks.length; // loop back to start
-      playIndex(next, true);
-    }
-
-    function prevTrack() {
-      const prev = (currentIndex - 1 + tracks.length) % tracks.length;
-      playIndex(prev, true);
-    }
-
-    // Auto-advance when a song ends
-    player.addEventListener("ended", nextTrack);
-
-    // Update UI on play/pause
-    player.addEventListener("play", () => setNowPlaying(`Playing: ${tracks[currentIndex].title}`));
-    player.addEventListener("pause", () => setNowPlaying(`Paused: ${tracks[currentIndex].title}`));
-
-    prevBtn.addEventListener("click", prevTrack);
-    nextBtn.addEventListener("click", nextTrack);
-    playPauseBtn.addEventListener("click", () => {
-      if (player.paused) player.play();
-      else player.pause();
-    });
-
-    // Init
-    renderPlaylist();
-    playIndex(0, false);
-  </script>
+	</script>
+	<script src="/js/album-player.js"></script>
 </body>
 </html>

--- a/jeisfeld/web/wasser/index.html
+++ b/jeisfeld/web/wasser/index.html
@@ -4,175 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Solea lebt! - Wasser</title>
-<style>
-body {
-	font-family: system-ui, sans-serif;
-	margin: 0;
-	background: #111;
-	color: #eee;
-}
-
-.wrap {
-	max-width: 900px;
-	margin: 0 auto;
-	padding: 24px;
-	display: grid;
-	gap: 24px;
-	grid-template-columns: 280px 1fr;
-}
-
-img {
-	width: 100%;
-	border-radius: 12px;
-	box-shadow: 0 8px 30px rgba(0, 0, 0, .4);
-}
-
-.album-links {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, 72px);
-	gap: 10px;
-	margin-top: 14px;
-}
-
-.album-links a {
-	display: block;
-	border-radius: 8px;
-}
-
-.album-links img {
-	display: block;
-	border-radius: 8px;
-	box-shadow: 0 4px 14px rgba(0, 0, 0, .4);
-	transition: opacity .2s;
-}
-
-.album-links a:hover img,
-.album-links a:focus-visible img {
-	opacity: .75;
-}
-
-h1 {
-	margin: 0 0 8px;
-	font-size: 24px;
-}
-
-audio {
-	width: 100%;
-	margin: 12px 0 8px;
-}
-
-ul {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-	border-radius: 12px;
-	overflow: hidden;
-	border: 1px solid #2a2a2a;
-}
-
-li {
-	display: flex;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 3px 14px;
-	cursor: pointer;
-	background: #161616;
-	border-top: 1px solid #2a2a2a;
-}
-
-li:first-child {
-	border-top: 0;
-}
-
-li:hover {
-	background: #1d1d1d;
-}
-
-li.active {
-	background: #2a2a2a;
-}
-
-.meta {
-	opacity: .7;
-	font-size: 13px;
-}
-
-.row {
-	display: flex;
-	align-items: baseline;
-	gap: 10px;
-}
-
-button {
-	background: #2a2a2a;
-	color: #eee;
-	border: 1px solid #3a3a3a;
-	padding: 10px 12px;
-	border-radius: 10px;
-	cursor: pointer;
-}
-
-button:hover {
-	background: #333;
-}
-
-.icon-btn {
-	font-size: 18px;
-	line-height: 1;
-	min-width: 46px;
-	padding: 10px;
-}
-
-.social-links {
-	margin-top: 14px;
-	display: grid;
-	gap: 8px;
-}
-
-.social-links a {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 8px 10px;
-	background: #161616;
-	border: 1px solid #2a2a2a;
-	border-radius: 10px;
-	color: #eee;
-	text-decoration: none;
-}
-
-.social-links a:hover {
-	background: #1d1d1d;
-}
-
-.icon {
-	width: 20px;
-	height: 20px;
-	fill: currentColor;
-}
-
-@media ( max-width : 760px) {
-	.wrap {
-		grid-template-columns: 1fr;
-	}
-}
-
-
-@media ( max-width : 480px) {
-	.wrap {
-		padding: 16px;
-	}
-
-	li {
-		padding: 3px 8px;
-	}
-
-	.row {
-		font-size: 14px;
-		gap: 6px;
-	}
-}
-</style>
+<link rel="stylesheet" href="/css/album-player.css" />
 </head>
 <body>
 	<div class="wrap">
@@ -227,7 +59,7 @@ button:hover {
 
 			<audio id="player" controls preload="metadata"></audio>
 
-			<div style="display: flex; gap: 10px; margin: 10px 0 14px;">
+			<div class="player-controls">
 				<button id="prevBtn" class="icon-btn" type="button" aria-label="Previous track" title="Previous track">⏮</button>
 				<button id="playPauseBtn" class="icon-btn" type="button" aria-label="Play or pause" title="Play/Pause">⏯</button>
 				<button id="nextBtn" class="icon-btn" type="button" aria-label="Next track" title="Next track">⏭</button>
@@ -238,25 +70,8 @@ button:hover {
 	</div>
 
 	<script>
-    // Add future albums here; the current album is omitted automatically.
-	const albums = [
-	  { slug: "indiewelt", title: "In die Welt" },
-	  { slug: "wasser", title: "Wasser" },
-	  { slug: "neuewellen", title: "Neue Wellen" },
-	];
 	const currentAlbum = "wasser";
-	const albumLinks = document.getElementById("albumLinks");
-	albums.filter((album) => album.slug !== currentAlbum).forEach((album) => {
-	  const link = document.createElement("a");
-	  const cover = document.createElement("img");
-	  link.href = `/${album.slug}/`;
-	  link.title = album.title;
-	  link.setAttribute("aria-label", `Open album ${album.title}`);
-	  cover.src = `/${album.slug}/cover.jpg`;
-	  cover.alt = `${album.title} album cover`;
-	  link.appendChild(cover);
-	  albumLinks.appendChild(link);
-	});
+
 
     // 1) Edit this list to match your MP3 files
 	const tracks = [
@@ -281,97 +96,7 @@ button:hover {
 	  { title: "Benutze mich", file: "tracks/19 Benutze mich.mp3" },
 	  { title: "(V)Erleben", file: "tracks/20 (V)Erleben.mp3" },
 	];
-
-
-    const player = document.getElementById("player");
-    const playlistEl = document.getElementById("playlist");
-    const nowPlayingEl = document.getElementById("nowPlaying");
-    const prevBtn = document.getElementById("prevBtn");
-    const nextBtn = document.getElementById("nextBtn");
-    const playPauseBtn = document.getElementById("playPauseBtn");
-
-    let currentIndex = 0;
-
-    function renderPlaylist() {
-      playlistEl.innerHTML = "";
-      tracks.forEach((t, i) => {
-        const li = document.createElement("li");
-        li.dataset.index = i;
-
-        const left = document.createElement("div");
-        left.className = "row";
-        left.innerHTML = `<strong>${String(i + 1).padStart(2, "0")}.</strong> <span>${t.title}</span>`;
-
-        const right = document.createElement("div");
-        right.className = "meta";
-        right.textContent = "▶";
-
-        li.appendChild(left);
-        li.appendChild(right);
-
-        li.addEventListener("click", () => playIndex(i, true));
-        playlistEl.appendChild(li);
-      });
-      highlightActive();
-    }
-
-    function highlightActive() {
-      [...playlistEl.children].forEach((li) => li.classList.remove("active"));
-      const active = playlistEl.children[currentIndex];
-      if (active) active.classList.add("active");
-    }
-
-    function setNowPlaying(text) {
-      nowPlayingEl.textContent = text;
-    }
-
-    function playIndex(index, autoplay = false) {
-      if (index < 0 || index >= tracks.length) return;
-      currentIndex = index;
-
-      player.src = tracks[currentIndex].file;
-      player.load();
-
-      highlightActive();
-      setNowPlaying(`Selected: ${tracks[currentIndex].title}`);
-
-      if (autoplay) {
-        // Note: some browsers require a user gesture before audio playback.
-        player.play().then(() => {
-          setNowPlaying(`Playing: ${tracks[currentIndex].title}`);
-        }).catch(() => {
-          setNowPlaying(`Ready to play: ${tracks[currentIndex].title} (press Play)`);
-        });
-      }
-    }
-
-    function nextTrack() {
-      const next = (currentIndex + 1) % tracks.length; // loop back to start
-      playIndex(next, true);
-    }
-
-    function prevTrack() {
-      const prev = (currentIndex - 1 + tracks.length) % tracks.length;
-      playIndex(prev, true);
-    }
-
-    // Auto-advance when a song ends
-    player.addEventListener("ended", nextTrack);
-
-    // Update UI on play/pause
-    player.addEventListener("play", () => setNowPlaying(`Playing: ${tracks[currentIndex].title}`));
-    player.addEventListener("pause", () => setNowPlaying(`Paused: ${tracks[currentIndex].title}`));
-
-    prevBtn.addEventListener("click", prevTrack);
-    nextBtn.addEventListener("click", nextTrack);
-    playPauseBtn.addEventListener("click", () => {
-      if (player.paused) player.play();
-      else player.pause();
-    });
-
-    // Init
-    renderPlaylist();
-    playIndex(0, false);
-  </script>
+	</script>
+	<script src="/js/album-player.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Several album pages (In die Welt, Wasser, Neue Wellen, Jam Sessions) contained large duplicated inline CSS and JavaScript, making maintenance error-prone.
- Consolidating the shared layout, player styles and player logic reduces repetition and centralizes behavior.
- The goal is to keep each page limited to its `currentAlbum` and `tracks` data while sharing common assets.

### Description
- Extracted shared styling into `jeisfeld/web/css/album-player.css` and removed the duplicated inline `<style>` blocks from each album page.
- Extracted the shared player and album-navigation logic into `jeisfeld/web/js/album-player.js`, responsible for album links, playlist rendering, playback controls and track navigation.
- Updated `jeisfeld/web/{indiewelt,wasser,neuewellen,jamsessions}/index.html` to include only `const currentAlbum` and the page-specific `tracks` array and to load the shared CSS and JS assets.
- Replaced the inline control wrapper with the `.player-controls` class so the visual layout is served from the shared stylesheet.

### Testing
- Ran `node --check jeisfeld/web/js/album-player.js` to validate the new JS file syntax and it succeeded.
- Parsed the four refactored pages with a Python HTML parser to verify each page references `/css/album-player.css` and `/js/album-player.js` and no longer contains embedded player CSS or duplicated functions, and the check passed.
- Ran `git diff --check` to ensure there are no whitespace or patch issues and the check reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a679bdeb69083228cfaebc8bd4dfa29)